### PR TITLE
Wasm GC Decoding Phase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,7 @@ ktlint_standard_no-empty-first-line-in-method-block = disabled
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_property-naming = disabled
 ktlint_standard_string-template-indent = disabled
+ktlint_standard_value-argument-comment = disabled
 
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/AggregateInstructions.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/AggregateInstructions.kt
@@ -1,0 +1,66 @@
+package io.github.charlietap.chasm.ast.instruction
+
+import io.github.charlietap.chasm.ast.module.Index
+import kotlin.jvm.JvmInline
+
+sealed interface AggregateInstruction : Instruction {
+
+    @JvmInline
+    value class StructNew(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    @JvmInline
+    value class StructNewDefault(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data class StructGet(val typeIndex: Index.TypeIndex, val fieldIndex: Index.FieldIndex) : AggregateInstruction
+
+    data class StructGetSigned(val typeIndex: Index.TypeIndex, val fieldIndex: Index.FieldIndex) : AggregateInstruction
+
+    data class StructGetUnsigned(val typeIndex: Index.TypeIndex, val fieldIndex: Index.FieldIndex) : AggregateInstruction
+
+    data class StructSet(val typeIndex: Index.TypeIndex, val fieldIndex: Index.FieldIndex) : AggregateInstruction
+
+    @JvmInline
+    value class ArrayNew(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data class ArrayNewFixed(val typeIndex: Index.TypeIndex, val size: UInt) : AggregateInstruction
+
+    @JvmInline
+    value class ArrayNewDefault(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data class ArrayNewData(val typeIndex: Index.TypeIndex, val dataIndex: Index.DataIndex) : AggregateInstruction
+
+    data class ArrayNewElem(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
+
+    @JvmInline
+    value class ArrayGet(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    @JvmInline
+    value class ArrayGetSigned(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    @JvmInline
+    value class ArrayGetUnsigned(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    @JvmInline
+    value class ArraySet(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data object ArrayLen : AggregateInstruction
+
+    @JvmInline
+    value class ArrayFill(val typeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data class ArrayCopy(val sourceTypeIndex: Index.TypeIndex, val destinationTypeIndex: Index.TypeIndex) : AggregateInstruction
+
+    data class ArrayInitData(val typeIndex: Index.TypeIndex, val dataIndex: Index.DataIndex) : AggregateInstruction
+
+    data class ArrayInitElem(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
+
+    data object RefI31 : AggregateInstruction
+
+    data object I31GetSigned : AggregateInstruction
+
+    data object I31GetUnsigned : AggregateInstruction
+
+    data object AnyConvertExtern : AggregateInstruction
+
+    data object ExternConvertAny : AggregateInstruction
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/AggregateInstructions.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/AggregateInstructions.kt
@@ -29,7 +29,7 @@ sealed interface AggregateInstruction : Instruction {
 
     data class ArrayNewData(val typeIndex: Index.TypeIndex, val dataIndex: Index.DataIndex) : AggregateInstruction
 
-    data class ArrayNewElem(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
+    data class ArrayNewElement(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
 
     @JvmInline
     value class ArrayGet(val typeIndex: Index.TypeIndex) : AggregateInstruction
@@ -52,7 +52,7 @@ sealed interface AggregateInstruction : Instruction {
 
     data class ArrayInitData(val typeIndex: Index.TypeIndex, val dataIndex: Index.DataIndex) : AggregateInstruction
 
-    data class ArrayInitElem(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
+    data class ArrayInitElement(val typeIndex: Index.TypeIndex, val elementIndex: Index.ElementIndex) : AggregateInstruction
 
     data object RefI31 : AggregateInstruction
 

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/ControlInstruction.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/ControlInstruction.kt
@@ -1,6 +1,7 @@
 package io.github.charlietap.chasm.ast.instruction
 
 import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ValueType
 import kotlin.jvm.JvmInline
 
@@ -39,6 +40,18 @@ sealed interface ControlInstruction : Instruction {
 
     @JvmInline
     value class BrOnNonNull(val labelIndex: Index.LabelIndex) : ControlInstruction
+
+    data class BrOnCast(
+        val labelIndex: Index.LabelIndex,
+        val srcReferenceType: ReferenceType,
+        val dstReferenceType: ReferenceType,
+    ) : ControlInstruction
+
+    data class BrOnCastFail(
+        val labelIndex: Index.LabelIndex,
+        val srcReferenceType: ReferenceType,
+        val dstReferenceType: ReferenceType,
+    ) : ControlInstruction
 
     data object Return : ControlInstruction
 

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/ReferenceInstruction.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/instruction/ReferenceInstruction.kt
@@ -2,6 +2,7 @@ package io.github.charlietap.chasm.ast.instruction
 
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.ReferenceType
 import kotlin.jvm.JvmInline
 
 sealed interface ReferenceInstruction : Instruction {
@@ -14,4 +15,12 @@ sealed interface ReferenceInstruction : Instruction {
 
     @JvmInline
     value class RefFunc(val funcIdx: Index.FunctionIndex) : ReferenceInstruction
+
+    data object RefEq : ReferenceInstruction
+
+    @JvmInline
+    value class RefTest(val referenceType: ReferenceType) : ReferenceInstruction
+
+    @JvmInline
+    value class RefCast(val referenceType: ReferenceType) : ReferenceInstruction
 }

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/module/Index.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/module/Index.kt
@@ -32,4 +32,7 @@ sealed interface Index {
 
     @JvmInline
     value class TypeIndex(override val idx: UInt) : Index
+
+    @JvmInline
+    value class FieldIndex(override val idx: UInt) : Index
 }

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/module/Type.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/module/Type.kt
@@ -1,9 +1,9 @@
 package io.github.charlietap.chasm.ast.module
 
 import io.github.charlietap.chasm.ast.module.Index.TypeIndex
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.RecursiveType
 
 data class Type(
     val idx: TypeIndex,
-    val functionType: FunctionType,
+    val recursiveType: RecursiveType,
 )

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/ArrayType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/ArrayType.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class ArrayType(val field: FieldType) : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/BottomType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/BottomType.kt
@@ -1,0 +1,3 @@
+package io.github.charlietap.chasm.ast.type
+
+sealed interface BottomType : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/CompositeType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/CompositeType.kt
@@ -8,8 +8,8 @@ sealed interface CompositeType : Type {
     value class Function(val functionType: FunctionType) : CompositeType
 
     @JvmInline
-    value class Struct(val fields: List<FieldType>) : CompositeType
+    value class Struct(val structType: StructType) : CompositeType
 
     @JvmInline
-    value class Array(val field: FieldType) : CompositeType
+    value class Array(val arrayType: ArrayType) : CompositeType
 }

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/CompositeType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/CompositeType.kt
@@ -1,0 +1,15 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+sealed interface CompositeType : Type {
+
+    @JvmInline
+    value class Function(val functionType: FunctionType) : CompositeType
+
+    @JvmInline
+    value class Struct(val fields: List<FieldType>) : CompositeType
+
+    @JvmInline
+    value class Array(val field: FieldType) : CompositeType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/DefinedType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/DefinedType.kt
@@ -1,0 +1,3 @@
+package io.github.charlietap.chasm.ast.type
+
+data class DefinedType(val recursiveType: RecursiveType, val recursiveTypeIndex: Int)

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/FieldType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/FieldType.kt
@@ -1,12 +1,6 @@
 package io.github.charlietap.chasm.ast.type
 
-import kotlin.jvm.JvmInline
-
-sealed interface FieldType : Type {
-
-    @JvmInline
-    value class MutableStorageType(val storageType: StorageType) : FieldType
-
-    @JvmInline
-    value class ImmutableStorageType(val storageType: StorageType) : FieldType
-}
+data class FieldType(
+    val storageType: StorageType,
+    val mutability: Mutability,
+) : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/FieldType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/FieldType.kt
@@ -1,0 +1,12 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+sealed interface FieldType : Type {
+
+    @JvmInline
+    value class MutableStorageType(val storageType: StorageType) : FieldType
+
+    @JvmInline
+    value class ImmutableStorageType(val storageType: StorageType) : FieldType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/GlobalType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/GlobalType.kt
@@ -3,9 +3,4 @@ package io.github.charlietap.chasm.ast.type
 data class GlobalType(
     val valueType: ValueType,
     val mutability: Mutability,
-) : Type {
-    enum class Mutability {
-        Const,
-        Var,
-    }
-}
+) : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/HeapType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/HeapType.kt
@@ -3,17 +3,30 @@ package io.github.charlietap.chasm.ast.type
 import io.github.charlietap.chasm.ast.module.Index
 import kotlin.jvm.JvmInline
 
-sealed interface HeapType : Type {
+sealed interface HeapType : Type
 
-    data object Func : HeapType
+sealed interface AbstractHeapType : HeapType {
 
-    data object Extern : HeapType
+    data object Func : AbstractHeapType
 
-    @JvmInline
-    value class TypeIndex(val index: Index.TypeIndex) : HeapType
+    data object NoFunc : AbstractHeapType
 
-    @JvmInline
-    value class FuncType(val functionType: FunctionType) : HeapType
+    data object Extern : AbstractHeapType
 
-    data object Bottom : HeapType
+    data object NoExtern : AbstractHeapType
+
+    data object Any : AbstractHeapType
+
+    data object Eq : AbstractHeapType
+
+    data object Struct : AbstractHeapType
+
+    data object Array : AbstractHeapType
+
+    data object I31 : AbstractHeapType
+
+    data object None : AbstractHeapType
 }
+
+@JvmInline
+value class ConcreteHeapType(val index: Index.TypeIndex) : HeapType

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/HeapType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/HeapType.kt
@@ -5,7 +5,7 @@ import kotlin.jvm.JvmInline
 
 sealed interface HeapType : Type
 
-sealed interface AbstractHeapType : HeapType {
+sealed interface AbstractHeapType : HeapType, BottomType {
 
     data object Func : AbstractHeapType
 
@@ -28,5 +28,14 @@ sealed interface AbstractHeapType : HeapType {
     data object None : AbstractHeapType
 }
 
-@JvmInline
-value class ConcreteHeapType(val index: Index.TypeIndex) : HeapType
+sealed interface ConcreteHeapType : HeapType {
+
+    @JvmInline
+    value class TypeIndex(val index: Index.TypeIndex) : ConcreteHeapType
+
+    @JvmInline
+    value class RecursiveTypeIndex(val index: Int) : ConcreteHeapType
+
+    @JvmInline
+    value class Defined(val definedType: DefinedType) : ConcreteHeapType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/Mutability.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/Mutability.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.ast.type
+
+enum class Mutability {
+    Const,
+    Var,
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/PackedType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/PackedType.kt
@@ -1,0 +1,12 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+sealed interface PackedType : Type {
+
+    @JvmInline
+    value class I8(val value: Byte) : PackedType
+
+    @JvmInline
+    value class I16(val value: Short) : PackedType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/PackedType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/PackedType.kt
@@ -1,12 +1,8 @@
 package io.github.charlietap.chasm.ast.type
 
-import kotlin.jvm.JvmInline
-
 sealed interface PackedType : Type {
 
-    @JvmInline
-    value class I8(val value: Byte) : PackedType
+    data object I8 : PackedType
 
-    @JvmInline
-    value class I16(val value: Short) : PackedType
+    data object I16 : PackedType
 }

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/RecursiveType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/RecursiveType.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class RecursiveType(val subTypes: List<SubType>) : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/StorageType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/StorageType.kt
@@ -1,0 +1,12 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+sealed interface StorageType : Type {
+
+    @JvmInline
+    value class Value(val type: ValueType) : StorageType
+
+    @JvmInline
+    value class Packed(val type: PackedType) : StorageType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/StructType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/StructType.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.ast.type
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class StructType(val fields: List<FieldType>) : Type

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/SubType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/SubType.kt
@@ -1,19 +1,17 @@
 package io.github.charlietap.chasm.ast.type
 
-import io.github.charlietap.chasm.ast.module.Index
-
 sealed interface SubType : Type {
 
-    val typeIndices: List<Index.TypeIndex>
     val compositeType: CompositeType
+    val superTypes: List<HeapType>
 
     data class Open(
-        override val typeIndices: List<Index.TypeIndex>,
+        override val superTypes: List<HeapType>,
         override val compositeType: CompositeType,
     ) : SubType
 
     data class Final(
-        override val typeIndices: List<Index.TypeIndex>,
+        override val superTypes: List<HeapType>,
         override val compositeType: CompositeType,
     ) : SubType
 }

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/SubType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/SubType.kt
@@ -1,0 +1,19 @@
+package io.github.charlietap.chasm.ast.type
+
+import io.github.charlietap.chasm.ast.module.Index
+
+sealed interface SubType : Type {
+
+    val typeIndices: List<Index.TypeIndex>
+    val compositeType: CompositeType
+
+    data class Open(
+        override val typeIndices: List<Index.TypeIndex>,
+        override val compositeType: CompositeType,
+    ) : SubType
+
+    data class Final(
+        override val typeIndices: List<Index.TypeIndex>,
+        override val compositeType: CompositeType,
+    ) : SubType
+}

--- a/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/ValueType.kt
+++ b/ast/src/commonMain/kotlin/io/github/charlietap/chasm/ast/type/ValueType.kt
@@ -2,7 +2,7 @@ package io.github.charlietap.chasm.ast.type
 
 import kotlin.jvm.JvmInline
 
-sealed interface ValueType {
+sealed interface ValueType : BottomType {
     @JvmInline
     value class Number(val numberType: NumberType) : ValueType
 

--- a/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/embedding/FunctionTest.kt
+++ b/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/embedding/FunctionTest.kt
@@ -4,6 +4,7 @@ import io.github.charlietap.chasm.executor.runtime.instance.ExternalValue
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction
 import io.github.charlietap.chasm.executor.runtime.store.Address
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.store
 import io.github.charlietap.chasm.fixture.type.functionType
 import kotlin.test.Test
@@ -18,12 +19,13 @@ class FunctionTest {
         val funcType = functionType()
         val hostFunction: HostFunction = { emptyList() }
 
+        val expectedType = funcType.definedType()
         val expected = ExternalValue.Function(Address.Function(0))
 
         val actual = function(store, funcType, hostFunction)
 
         assertEquals(expected, actual)
-        assertEquals(funcType, store.functions[0].type)
+        assertEquals(expectedType, store.functions[0].type)
         assertEquals(hostFunction, (store.functions[0] as? FunctionInstance.HostFunction)?.function)
     }
 }

--- a/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/embedding/table/WriteTableTest.kt
+++ b/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/embedding/table/WriteTableTest.kt
@@ -1,7 +1,7 @@
 package io.github.charlietap.chasm.embedding.table
 
 import io.github.charlietap.chasm.ChasmResult
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.error.ChasmError
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
@@ -18,7 +18,7 @@ class WriteTableTest {
 
         val functionAddress = functionAddress()
         val value = ReferenceValue.FunctionAddress(functionAddress)
-        val instance = tableInstance(elements = mutableListOf(ReferenceValue.Null(HeapType.Func)))
+        val instance = tableInstance(elements = mutableListOf(ReferenceValue.Null(AbstractHeapType.Func)))
         val store = store(tables = mutableListOf(instance))
         val address = Address.Table(0)
 

--- a/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/integration/ReferenceTest.kt
+++ b/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/integration/ReferenceTest.kt
@@ -1,7 +1,7 @@
 package io.github.charlietap.chasm.integration
 
 import io.github.charlietap.chasm.ChasmResult
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
@@ -19,7 +19,7 @@ class ReferenceTest {
             fileDirectory = FILE_DIR,
         )
 
-        val expected = listOf(ReferenceValue.Null(HeapType.Func))
+        val expected = listOf(ReferenceValue.Null(AbstractHeapType.Func))
 
         assertEquals(ChasmResult.Success(expected), result)
     }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/BinaryInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/BinaryInstructionDecoder.kt
@@ -15,6 +15,8 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.parametric.Pa
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.prefix.BinaryPrefixInstructionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.prefix.PrefixInstructionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference.BinaryReferenceInstructionDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference.REF_AS_NON_NULL
+import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference.REF_NULL
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference.ReferenceInstructionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.table.BinaryTableInstructionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.table.TableInstructionDecoder

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/Opcode.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/Opcode.kt
@@ -163,11 +163,6 @@ internal const val I64_EXTEND8_S: UByte = 0xC2u
 internal const val I64_EXTEND16_S: UByte = 0xC3u
 internal const val I64_EXTEND32_S: UByte = 0xC4u
 
-internal const val REF_NULL: UByte = 0xD0u
-internal const val REF_ISNULL: UByte = 0xD1u
-internal const val REF_FUNC: UByte = 0xD2u
-internal const val REF_AS_NON_NULL: UByte = 0xD4u
-
 internal const val DROP: UByte = 0x1Au
 internal const val SELECT: UByte = 0x1Bu
 internal const val SELECT_W_TYPE: UByte = 0x1Cu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoder.kt
@@ -5,12 +5,9 @@ import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.instruction.ControlInstruction.BlockType
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.BinaryValueTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_NUMBER_I32
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_EXTERNREF
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_FUNCREF
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_REF
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_REF_NULL
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_VECTOR_V128
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.NUMBER_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.REFERENCE_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VECTOR_TYPE_RANGE
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
@@ -34,9 +31,9 @@ internal fun BinaryBlockTypeDecoder(
             reader.byte() // consume it
             BlockType.Empty
         }
-        in VALUE_TYPE_REFERENCE_EXTERNREF..VALUE_TYPE_REFERENCE_FUNCREF,
-        in VALUE_TYPE_REFERENCE_REF_NULL..VALUE_TYPE_REFERENCE_REF,
-        in VALUE_TYPE_VECTOR_V128..VALUE_TYPE_NUMBER_I32,
+        in NUMBER_TYPE_RANGE,
+        in VECTOR_TYPE_RANGE,
+        in REFERENCE_TYPE_RANGE,
         -> {
             BlockType.ValType(valueTypeDecoder(reader).bind())
         }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoder.kt
@@ -39,9 +39,8 @@ internal fun BinaryBlockTypeDecoder(
         }
 
         else -> {
-            // Not using TypeIndexDecoder here as it's stored in a signed leb s33
-            val idx = reader.long().bind()
-            BlockType.SignedTypeIndex(Index.TypeIndex(idx.toUInt()))
+            val idx = reader.s33().bind()
+            BlockType.SignedTypeIndex(Index.TypeIndex(idx))
         }
     }
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryCastFlagsDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryCastFlagsDecoder.kt
@@ -1,0 +1,25 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryCastFlagsDecoder(
+    reader: WasmBinaryReader,
+): Result<CastFlags, WasmDecodeError> = binding {
+    when (val flagsByte = reader.ubyte().bind()) {
+        NON_NULL_BOTH_CAST_FLAGS -> CastFlags(Nullability.NON_NULL, Nullability.NON_NULL)
+        NULL_TO_NON_NULL_CAST_FLAGS -> CastFlags(Nullability.NULL, Nullability.NON_NULL)
+        NON_NULL_TO_NULL_CAST_FLAGS -> CastFlags(Nullability.NON_NULL, Nullability.NULL)
+        NULL_BOTH_CAST_FLAGS -> CastFlags(Nullability.NULL, Nullability.NULL)
+        else -> Err(InstructionDecodeError.InvalidCastFlags(flagsByte)).bind<CastFlags>()
+    }
+}
+
+internal const val NON_NULL_BOTH_CAST_FLAGS: UByte = 0x00u
+internal const val NULL_TO_NON_NULL_CAST_FLAGS: UByte = 0x01u
+internal const val NON_NULL_TO_NULL_CAST_FLAGS: UByte = 0x02u
+internal const val NULL_BOTH_CAST_FLAGS: UByte = 0x03u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoder.kt
@@ -55,6 +55,7 @@ internal fun BinaryControlInstructionDecoder(
         tableIndexDecoder = ::BinaryTableIndexDecoder,
         labelIndexDecoder = ::BinaryLabelIndexDecoder,
         vectorDecoder = ::BinaryVectorDecoder,
+        prefixedControlInstructionDecoder = ::BinaryPrefixedControlInstructionDecoder,
     )
 
 internal fun BinaryControlInstructionDecoder(
@@ -68,6 +69,7 @@ internal fun BinaryControlInstructionDecoder(
     tableIndexDecoder: TableIndexDecoder,
     labelIndexDecoder: LabelIndexDecoder,
     vectorDecoder: VectorDecoder<Index.LabelIndex>,
+    prefixedControlInstructionDecoder: PrefixedControlInstructionDecoder,
 ): Result<Instruction, WasmDecodeError> = binding {
     when (opcode) {
         UNREACHABLE -> ControlInstruction.Unreachable
@@ -135,7 +137,10 @@ internal fun BinaryControlInstructionDecoder(
             val labelIndex = labelIndexDecoder(reader).bind()
             ControlInstruction.BrOnNonNull(labelIndex)
         }
+        PREFIXED_CONTROL_INSTRUCTION -> prefixedControlInstructionDecoder(reader).bind()
 
         else -> Err(InstructionDecodeError.InvalidControlInstruction(opcode)).bind<Instruction>()
     }
 }
+
+internal const val PREFIXED_CONTROL_INSTRUCTION: UByte = 0xFBu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryPrefixedControlInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryPrefixedControlInstructionDecoder.kt
@@ -1,0 +1,66 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.instruction.ControlInstruction
+import io.github.charlietap.chasm.ast.instruction.Instruction
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryLabelIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.LabelIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.BinaryHeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryPrefixedControlInstructionDecoder(
+    reader: WasmBinaryReader,
+): Result<Instruction, WasmDecodeError> =
+    BinaryPrefixedControlInstructionDecoder(
+        reader = reader,
+        labelIndexDecoder = ::BinaryLabelIndexDecoder,
+        castFlagsDecoder = ::BinaryCastFlagsDecoder,
+        heapTypeDecoder = ::BinaryHeapTypeDecoder,
+    )
+
+internal fun BinaryPrefixedControlInstructionDecoder(
+    reader: WasmBinaryReader,
+    labelIndexDecoder: LabelIndexDecoder,
+    castFlagsDecoder: CastFlagsDecoder,
+    heapTypeDecoder: HeapTypeDecoder,
+): Result<Instruction, WasmDecodeError> = binding {
+    when (val instruction = reader.uint().bind()) {
+        BR_ON_CAST,
+        BR_ON_CAST_FAIL,
+        -> {
+            val castFlags = castFlagsDecoder(reader).bind()
+            val labelIndex = labelIndexDecoder(reader).bind()
+            val srcHeapType = heapTypeDecoder(reader).bind()
+            val dstHeapType = heapTypeDecoder(reader).bind()
+
+            val srcReferenceType = if (castFlags.src == Nullability.NON_NULL) {
+                ReferenceType.Ref(srcHeapType)
+            } else {
+                ReferenceType.RefNull(srcHeapType)
+            }
+
+            val dstReferenceType = if (castFlags.dst == Nullability.NON_NULL) {
+                ReferenceType.Ref(dstHeapType)
+            } else {
+                ReferenceType.RefNull(dstHeapType)
+            }
+
+            if (instruction == BR_ON_CAST) {
+                ControlInstruction.BrOnCast(labelIndex, srcReferenceType, dstReferenceType)
+            } else {
+                ControlInstruction.BrOnCastFail(labelIndex, srcReferenceType, dstReferenceType)
+            }
+        }
+
+        else -> Err(InstructionDecodeError.InvalidPrefixedControlInstruction(instruction.toUByte())).bind<Instruction>()
+    }
+}
+
+internal const val BR_ON_CAST = 24u
+internal const val BR_ON_CAST_FAIL = 25u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/CastFlags.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/CastFlags.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+data class CastFlags(val src: Nullability, val dst: Nullability)
+
+enum class Nullability {
+    NULL,
+    NON_NULL,
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/CastFlagsDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/CastFlagsDecoder.kt
@@ -1,0 +1,7 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias CastFlagsDecoder = (WasmBinaryReader) -> Result<CastFlags, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/PrefixedControlInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/PrefixedControlInstructionDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.instruction.Instruction
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias PrefixedControlInstructionDecoder = (WasmBinaryReader) -> Result<Instruction, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryPrefixedReferenceInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryPrefixedReferenceInstructionDecoder.kt
@@ -1,0 +1,189 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.instruction.AggregateInstruction
+import io.github.charlietap.chasm.ast.instruction.Instruction
+import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryDataIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryElementIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryFieldIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryTypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.DataIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.ElementIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.FieldIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.BinaryHeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryPrefixedReferenceInstructionDecoder(
+    reader: WasmBinaryReader,
+): Result<Instruction, WasmDecodeError> =
+    BinaryPrefixedReferenceInstructionDecoder(
+        reader = reader,
+        dataIndexDecoder = ::BinaryDataIndexDecoder,
+        elementIndexDecoder = ::BinaryElementIndexDecoder,
+        fieldIndexDecoder = ::BinaryFieldIndexDecoder,
+        typeIndexDecoder = ::BinaryTypeIndexDecoder,
+        heapTypeDecoder = ::BinaryHeapTypeDecoder,
+    )
+
+internal fun BinaryPrefixedReferenceInstructionDecoder(
+    reader: WasmBinaryReader,
+    dataIndexDecoder: DataIndexDecoder,
+    elementIndexDecoder: ElementIndexDecoder,
+    fieldIndexDecoder: FieldIndexDecoder,
+    typeIndexDecoder: TypeIndexDecoder,
+    heapTypeDecoder: HeapTypeDecoder,
+): Result<Instruction, WasmDecodeError> = binding {
+    when (val instruction = reader.uint().bind()) {
+        STRUCT_NEW -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.StructNew(typeIndex)
+        }
+        STRUCT_NEW_DEFAULT -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.StructNewDefault(typeIndex)
+        }
+        STRUCT_GET -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val fieldIndex = fieldIndexDecoder(reader).bind()
+            AggregateInstruction.StructGet(typeIndex, fieldIndex)
+        }
+        STRUCT_GET_SIGNED -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val fieldIndex = fieldIndexDecoder(reader).bind()
+            AggregateInstruction.StructGetSigned(typeIndex, fieldIndex)
+        }
+        STRUCT_GET_UNSIGNED -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val fieldIndex = fieldIndexDecoder(reader).bind()
+            AggregateInstruction.StructGetUnsigned(typeIndex, fieldIndex)
+        }
+        STRUCT_SET -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val fieldIndex = fieldIndexDecoder(reader).bind()
+            AggregateInstruction.StructSet(typeIndex, fieldIndex)
+        }
+        ARRAY_NEW -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayNew(typeIndex)
+        }
+        ARRAY_NEW_DEFAULT -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayNewDefault(typeIndex)
+        }
+        ARRAY_NEW_FIXED -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val size = reader.uint().bind()
+            AggregateInstruction.ArrayNewFixed(typeIndex, size)
+        }
+        ARRAY_NEW_DATA -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val dataIndex = dataIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayNewData(typeIndex, dataIndex)
+        }
+        ARRAY_NEW_ELEMENT -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val elementIndex = elementIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayNewElement(typeIndex, elementIndex)
+        }
+        ARRAY_GET -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayGet(typeIndex)
+        }
+        ARRAY_GET_SIGNED -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayGetSigned(typeIndex)
+        }
+        ARRAY_GET_UNSIGNED -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayGetUnsigned(typeIndex)
+        }
+        ARRAY_SET -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArraySet(typeIndex)
+        }
+        ARRAY_LEN -> AggregateInstruction.ArrayLen
+        ARRAY_FILL -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayFill(typeIndex)
+        }
+        ARRAY_COPY -> {
+            val srcTypeIndex = typeIndexDecoder(reader).bind()
+            val dstTypeIndex = typeIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayCopy(srcTypeIndex, dstTypeIndex)
+        }
+        ARRAY_INIT_DATA -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val dataIndex = dataIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayInitData(typeIndex, dataIndex)
+        }
+        ARRAY_INIT_ELEMENT -> {
+            val typeIndex = typeIndexDecoder(reader).bind()
+            val elementIndex = elementIndexDecoder(reader).bind()
+            AggregateInstruction.ArrayInitElement(typeIndex, elementIndex)
+        }
+        REF_TEST -> {
+            val heapType = heapTypeDecoder(reader).bind()
+            val referenceType = ReferenceType.Ref(heapType)
+            ReferenceInstruction.RefTest(referenceType)
+        }
+        REF_TEST_NULL -> {
+            val heapType = heapTypeDecoder(reader).bind()
+            val referenceType = ReferenceType.RefNull(heapType)
+            ReferenceInstruction.RefTest(referenceType)
+        }
+        REF_CAST -> {
+            val heapType = heapTypeDecoder(reader).bind()
+            val referenceType = ReferenceType.Ref(heapType)
+            ReferenceInstruction.RefCast(referenceType)
+        }
+        REF_CAST_NULL -> {
+            val heapType = heapTypeDecoder(reader).bind()
+            val referenceType = ReferenceType.RefNull(heapType)
+            ReferenceInstruction.RefCast(referenceType)
+        }
+        ANY_CONVERT_EXTERN -> AggregateInstruction.AnyConvertExtern
+        EXTERN_CONVERT_ANY -> AggregateInstruction.ExternConvertAny
+        REF_I31 -> AggregateInstruction.RefI31
+        I31_GET_SIGNED -> AggregateInstruction.I31GetSigned
+        I31_GET_UNSIGNED -> AggregateInstruction.I31GetUnsigned
+        else -> Err(InstructionDecodeError.InvalidPrefixedReferenceInstruction(instruction.toUByte())).bind<Instruction>()
+    }
+}
+
+internal const val STRUCT_NEW = 0u
+internal const val STRUCT_NEW_DEFAULT = 1u
+internal const val STRUCT_GET = 2u
+internal const val STRUCT_GET_SIGNED = 3u
+internal const val STRUCT_GET_UNSIGNED = 4u
+internal const val STRUCT_SET = 5u
+internal const val ARRAY_NEW = 6u
+internal const val ARRAY_NEW_DEFAULT = 7u
+internal const val ARRAY_NEW_FIXED = 8u
+internal const val ARRAY_NEW_DATA = 9u
+internal const val ARRAY_NEW_ELEMENT = 10u
+internal const val ARRAY_GET = 11u
+internal const val ARRAY_GET_SIGNED = 12u
+internal const val ARRAY_GET_UNSIGNED = 13u
+internal const val ARRAY_SET = 14u
+internal const val ARRAY_LEN = 15u
+internal const val ARRAY_FILL = 16u
+internal const val ARRAY_COPY = 17u
+internal const val ARRAY_INIT_DATA = 18u
+internal const val ARRAY_INIT_ELEMENT = 19u
+internal const val REF_TEST = 20u
+internal const val REF_TEST_NULL = 21u
+internal const val REF_CAST = 22u
+internal const val REF_CAST_NULL = 23u
+internal const val ANY_CONVERT_EXTERN = 26u
+internal const val EXTERN_CONVERT_ANY = 27u
+internal const val REF_I31 = 28u
+internal const val I31_GET_SIGNED = 29u
+internal const val I31_GET_UNSIGNED = 30u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/PrefixedReferenceInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/PrefixedReferenceInstructionDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.instruction.Instruction
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias PrefixedReferenceInstructionDecoder = (WasmBinaryReader) -> Result<Instruction, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoder.kt
@@ -7,7 +7,7 @@ import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.ast.module.ElementSegment
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.BinaryExpressionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.ExpressionDecoder
@@ -62,14 +62,14 @@ internal fun BinaryElementSegmentDecoder(
                 Expression(listOf(ReferenceInstruction.RefFunc(idx)))
             }
 
-            ElementSegment(elemIdx, ReferenceType.RefNull(HeapType.Func), expressions, mode)
+            ElementSegment(elemIdx, ReferenceType.RefNull(AbstractHeapType.Func), expressions, mode)
         }
         SEGMENT_TYPE_PASSIVE_FUNCREFS -> {
 
             val elemKind = elementKindDecoder(reader).bind()
             val refType = elemKind.let { kind ->
                 when (kind) {
-                    ElementKind.FuncRef -> ReferenceType.RefNull(HeapType.Func)
+                    ElementKind.FuncRef -> ReferenceType.RefNull(AbstractHeapType.Func)
                 }
             }
 
@@ -92,7 +92,7 @@ internal fun BinaryElementSegmentDecoder(
             val elemKind = elementKindDecoder(reader).bind()
             val refType = elemKind.let { kind ->
                 when (kind) {
-                    ElementKind.FuncRef -> ReferenceType.RefNull(HeapType.Func)
+                    ElementKind.FuncRef -> ReferenceType.RefNull(AbstractHeapType.Func)
                 }
             }
 
@@ -108,7 +108,7 @@ internal fun BinaryElementSegmentDecoder(
             val elemKind = elementKindDecoder(reader).bind()
             val refType = elemKind.let { kind ->
                 when (kind) {
-                    ElementKind.FuncRef -> ReferenceType.RefNull(HeapType.Func)
+                    ElementKind.FuncRef -> ReferenceType.RefNull(AbstractHeapType.Func)
                 }
             }
 
@@ -128,7 +128,7 @@ internal fun BinaryElementSegmentDecoder(
 
             val expressions = expressionVectorDecoder(reader, expressionDecoder).bind()
 
-            ElementSegment(elemIdx, ReferenceType.RefNull(HeapType.Func), expressions.vector, mode)
+            ElementSegment(elemIdx, ReferenceType.RefNull(AbstractHeapType.Func), expressions.vector, mode)
         }
         SEGMENT_TYPE_PASSIVE_MANY_EXPRESSIONS -> {
 

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/BinaryFieldIndexDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/BinaryFieldIndexDecoder.kt
@@ -1,0 +1,10 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.section.index
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryFieldIndexDecoder(
+    reader: WasmBinaryReader,
+): Result<Index.FieldIndex, WasmDecodeError> = BinaryIndexDecoder(reader, Index::FieldIndex)

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/FieldIndexDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/FieldIndexDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.section.index
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias FieldIndexDecoder = (WasmBinaryReader) -> Result<Index.FieldIndex, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/type/BinaryTypeSectionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/type/BinaryTypeSectionDecoder.kt
@@ -4,8 +4,8 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Type
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.BinaryFunctionTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.FunctionTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive.BinaryRecursiveTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive.RecursiveTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorLengthDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorLengthDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
@@ -15,7 +15,7 @@ import io.github.charlietap.chasm.decoder.wasm.section.TypeSection
 
 internal class BinaryTypeSectionDecoder(
     private val vectorLengthDecoder: VectorLengthDecoder = ::BinaryVectorLengthDecoder,
-    private val functionTypeDecoder: FunctionTypeDecoder = ::BinaryFunctionTypeDecoder,
+    private val recursiveTypeDecoder: RecursiveTypeDecoder = ::BinaryRecursiveTypeDecoder,
 ) : TypeSectionDecoder {
     override fun invoke(
         reader: WasmBinaryReader,
@@ -25,8 +25,8 @@ internal class BinaryTypeSectionDecoder(
         val vectorLength = vectorLengthDecoder(reader).bind()
 
         val types = (0u..<vectorLength.length).map { idx ->
-            val functionType = functionTypeDecoder(reader).bind()
-            Type(Index.TypeIndex(idx), functionType)
+            val recursiveType = recursiveTypeDecoder(reader).bind()
+            Type(Index.TypeIndex(idx), recursiveType)
         }
 
         TypeSection(types)

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/BinaryMutabilityDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/BinaryMutabilityDecoder.kt
@@ -1,0 +1,23 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.Mutability
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryMutabilityDecoder(
+    reader: WasmBinaryReader,
+): Result<Mutability, WasmDecodeError> = binding {
+    when (val byte = reader.ubyte().bind()) {
+        CONST_MUTABILITY -> Ok(Mutability.Const)
+        VAR_MUTABILITY -> Ok(Mutability.Var)
+        else -> Err(TypeDecodeError.UnknownMutabilityFlag(byte))
+    }.bind()
+}
+
+internal const val CONST_MUTABILITY: UByte = 0x00u
+internal const val VAR_MUTABILITY: UByte = 0x01u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/MutabilityDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/MutabilityDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.Mutability
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias MutabilityDecoder = (WasmBinaryReader) -> Result<Mutability, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/ArrayTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/ArrayTypeDecoder.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.ArrayType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
-internal typealias ArrayTypeDecoder = (WasmBinaryReader) -> Result<CompositeType.Array, WasmDecodeError>
+internal typealias ArrayTypeDecoder = (WasmBinaryReader) -> Result<ArrayType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/ArrayTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/ArrayTypeDecoder.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
-internal typealias StorageTypeDecoder = (WasmBinaryReader) -> Result<StorageType, WasmDecodeError>
+internal typealias ArrayTypeDecoder = (WasmBinaryReader) -> Result<CompositeType.Array, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoder.kt
@@ -1,0 +1,25 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryArrayTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<CompositeType.Array, WasmDecodeError> =
+    BinaryArrayTypeDecoder(
+        reader = reader,
+        fieldTypeDecoder = ::BinaryFieldTypeDecoder,
+    )
+
+internal fun BinaryArrayTypeDecoder(
+    reader: WasmBinaryReader,
+    fieldTypeDecoder: FieldTypeDecoder,
+): Result<CompositeType.Array, WasmDecodeError> = binding {
+
+    val fieldType = fieldTypeDecoder(reader).bind()
+
+    CompositeType.Array(fieldType)
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoder.kt
@@ -2,13 +2,13 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
-import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.ArrayType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
 internal fun BinaryArrayTypeDecoder(
     reader: WasmBinaryReader,
-): Result<CompositeType.Array, WasmDecodeError> =
+): Result<ArrayType, WasmDecodeError> =
     BinaryArrayTypeDecoder(
         reader = reader,
         fieldTypeDecoder = ::BinaryFieldTypeDecoder,
@@ -17,9 +17,9 @@ internal fun BinaryArrayTypeDecoder(
 internal fun BinaryArrayTypeDecoder(
     reader: WasmBinaryReader,
     fieldTypeDecoder: FieldTypeDecoder,
-): Result<CompositeType.Array, WasmDecodeError> = binding {
+): Result<ArrayType, WasmDecodeError> = binding {
 
     val fieldType = fieldTypeDecoder(reader).bind()
 
-    CompositeType.Array(fieldType)
+    ArrayType(fieldType)
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryFieldTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryFieldTypeDecoder.kt
@@ -1,0 +1,29 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.BinaryMutabilityDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.MutabilityDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryFieldTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<FieldType, WasmDecodeError> =
+    BinaryFieldTypeDecoder(
+        reader = reader,
+        storageTypeDecoder = ::BinaryStorageTypeDecoder,
+        mutabilityDecoder = ::BinaryMutabilityDecoder,
+    )
+
+internal fun BinaryFieldTypeDecoder(
+    reader: WasmBinaryReader,
+    storageTypeDecoder: StorageTypeDecoder,
+    mutabilityDecoder: MutabilityDecoder,
+): Result<FieldType, WasmDecodeError> = binding {
+    val storageType = storageTypeDecoder(reader).bind()
+    val mutability = mutabilityDecoder(reader).bind()
+
+    FieldType(storageType, mutability)
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryPackedTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryPackedTypeDecoder.kt
@@ -1,0 +1,24 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.PackedType
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryPackedTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<PackedType, WasmDecodeError> = binding {
+    when (val encoded = reader.ubyte().bind()) {
+        PACKED_TYPE_I8 -> PackedType.I8
+        PACKED_TYPE_I16 -> PackedType.I16
+        else -> Err(TypeDecodeError.InvalidPackedType(encoded)).bind<PackedType>()
+    }
+}
+
+internal const val PACKED_TYPE_I8: UByte = 0x78u
+internal const val PACKED_TYPE_I16: UByte = 0x77u
+
+internal val PACKED_TYPE_RANGE = PACKED_TYPE_I16..PACKED_TYPE_I8

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStorageTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStorageTypeDecoder.kt
@@ -1,0 +1,44 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.BinaryValueTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.NUMBER_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.REFERENCE_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VECTOR_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryStorageTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<StorageType, WasmDecodeError> =
+    BinaryStorageTypeDecoder(
+        reader = reader,
+        packedTypeDecoder = ::BinaryPackedTypeDecoder,
+        valueTypeDecoder = ::BinaryValueTypeDecoder,
+    )
+
+internal fun BinaryStorageTypeDecoder(
+    reader: WasmBinaryReader,
+    packedTypeDecoder: PackedTypeDecoder,
+    valueTypeDecoder: ValueTypeDecoder,
+): Result<StorageType, WasmDecodeError> = binding {
+    when (val encoded = reader.peek().ubyte().bind()) {
+        in NUMBER_TYPE_RANGE,
+        in VECTOR_TYPE_RANGE,
+        in REFERENCE_TYPE_RANGE,
+        -> {
+            val valueType = valueTypeDecoder(reader).bind()
+            StorageType.Value(valueType)
+        }
+        in PACKED_TYPE_RANGE -> {
+            val packedType = packedTypeDecoder(reader).bind()
+            StorageType.Packed(packedType)
+        }
+        else -> Err(TypeDecodeError.InvalidStorageType(encoded)).bind<StorageType>()
+    }
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoder.kt
@@ -2,8 +2,8 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
-import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StructType
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
@@ -11,7 +11,7 @@ import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
 internal fun BinaryStructTypeDecoder(
     reader: WasmBinaryReader,
-): Result<CompositeType.Struct, WasmDecodeError> =
+): Result<StructType, WasmDecodeError> =
     BinaryStructTypeDecoder(
         reader = reader,
         fieldTypeDecoder = ::BinaryFieldTypeDecoder,
@@ -22,9 +22,9 @@ internal fun BinaryStructTypeDecoder(
     reader: WasmBinaryReader,
     fieldTypeDecoder: FieldTypeDecoder,
     vectorDecoder: VectorDecoder<FieldType>,
-): Result<CompositeType.Struct, WasmDecodeError> = binding {
+): Result<StructType, WasmDecodeError> = binding {
 
     val fieldTypes = vectorDecoder(reader, fieldTypeDecoder).bind()
 
-    CompositeType.Struct(fieldTypes.vector)
+    StructType(fieldTypes.vector)
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoder.kt
@@ -1,0 +1,30 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryStructTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<CompositeType.Struct, WasmDecodeError> =
+    BinaryStructTypeDecoder(
+        reader = reader,
+        fieldTypeDecoder = ::BinaryFieldTypeDecoder,
+        vectorDecoder = ::BinaryVectorDecoder,
+    )
+
+internal fun BinaryStructTypeDecoder(
+    reader: WasmBinaryReader,
+    fieldTypeDecoder: FieldTypeDecoder,
+    vectorDecoder: VectorDecoder<FieldType>,
+): Result<CompositeType.Struct, WasmDecodeError> = binding {
+
+    val fieldTypes = vectorDecoder(reader, fieldTypeDecoder).bind()
+
+    CompositeType.Struct(fieldTypes.vector)
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/FieldTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/FieldTypeDecoder.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.ast.type.FieldType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
-internal typealias StorageTypeDecoder = (WasmBinaryReader) -> Result<StorageType, WasmDecodeError>
+internal typealias FieldTypeDecoder = (WasmBinaryReader) -> Result<FieldType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/PackedTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/PackedTypeDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.PackedType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias PackedTypeDecoder = (WasmBinaryReader) -> Result<PackedType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StorageTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StorageTypeDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.PackedType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias StorageTypeDecoder = (WasmBinaryReader) -> Result<PackedType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StructTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StructTypeDecoder.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.StructType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
-internal typealias StructTypeDecoder = (WasmBinaryReader) -> Result<CompositeType.Struct, WasmDecodeError>
+internal typealias StructTypeDecoder = (WasmBinaryReader) -> Result<StructType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StructTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/StructTypeDecoder.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
-internal typealias StorageTypeDecoder = (WasmBinaryReader) -> Result<StorageType, WasmDecodeError>
+internal typealias StructTypeDecoder = (WasmBinaryReader) -> Result<CompositeType.Struct, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/BinaryCompositeTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/BinaryCompositeTypeDecoder.kt
@@ -1,0 +1,43 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.composite
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.ArrayTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.BinaryArrayTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.BinaryStructTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.StructTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.BinaryFunctionTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.FunctionTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryCompositeTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<CompositeType, WasmDecodeError> =
+    BinaryCompositeTypeDecoder(
+        reader = reader,
+        functionTypeDecoder = ::BinaryFunctionTypeDecoder,
+        structTypeDecoder = ::BinaryStructTypeDecoder,
+        arrayTypeDecoder = ::BinaryArrayTypeDecoder,
+    )
+
+internal fun BinaryCompositeTypeDecoder(
+    reader: WasmBinaryReader,
+    functionTypeDecoder: FunctionTypeDecoder,
+    structTypeDecoder: StructTypeDecoder,
+    arrayTypeDecoder: ArrayTypeDecoder,
+): Result<CompositeType, WasmDecodeError> = binding {
+    when (val compositeTypeByte = reader.ubyte().bind()) {
+        ARRAY_COMPOSITE_TYPE -> CompositeType.Array(arrayTypeDecoder(reader).bind())
+        STRUCT_COMPOSITE_TYPE -> CompositeType.Struct(structTypeDecoder(reader).bind())
+        FUNCTION_COMPOSITE_TYPE -> CompositeType.Function(functionTypeDecoder(reader).bind())
+        else -> Err(TypeDecodeError.InvalidCompositeType(compositeTypeByte)).bind<CompositeType>()
+    }
+}
+
+internal const val ARRAY_COMPOSITE_TYPE: UByte = 0x5Eu
+internal const val STRUCT_COMPOSITE_TYPE: UByte = 0x5Fu
+internal const val FUNCTION_COMPOSITE_TYPE: UByte = 0x60u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/CompositeTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/CompositeTypeDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.composite
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias CompositeTypeDecoder = (WasmBinaryReader) -> Result<CompositeType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoder.kt
@@ -1,12 +1,10 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.function
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.result.BinaryResultTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.result.ResultTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
@@ -21,11 +19,6 @@ internal fun BinaryFunctionTypeDecoder(
     reader: WasmBinaryReader,
     resultTypeDecoder: ResultTypeDecoder,
 ): Result<FunctionType, WasmDecodeError> = binding {
-    val byte = reader.ubyte().bind()
-
-    if (byte != 0x60.toUByte()) {
-        Err(TypeDecodeError.InvalidFunctionType(byte)).bind<Nothing>()
-    }
 
     val params = resultTypeDecoder(reader).bind()
     val results = resultTypeDecoder(reader).bind()

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/global/BinaryGlobalTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/global/BinaryGlobalTypeDecoder.kt
@@ -1,13 +1,12 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.global
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.type.GlobalType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.BinaryMutabilityDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.MutabilityDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.BinaryValueTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
@@ -16,17 +15,15 @@ internal fun BinaryGlobalTypeDecoder(
 ): Result<GlobalType, WasmDecodeError> = BinaryGlobalTypeDecoder(
     reader = reader,
     valueTypeDecoder = ::BinaryValueTypeDecoder,
+    mutabilityDecoder = ::BinaryMutabilityDecoder,
 )
 
 internal fun BinaryGlobalTypeDecoder(
     reader: WasmBinaryReader,
     valueTypeDecoder: ValueTypeDecoder,
+    mutabilityDecoder: MutabilityDecoder,
 ): Result<GlobalType, WasmDecodeError> = binding {
     val valueType = valueTypeDecoder(reader).bind()
-    val mutability = when (val byte = reader.ubyte().bind()) {
-        0u.toUByte() -> Ok(GlobalType.Mutability.Const)
-        1u.toUByte() -> Ok(GlobalType.Mutability.Var)
-        else -> Err(TypeDecodeError.UnknownMutabilityFlag(byte))
-    }.bind()
+    val mutability = mutabilityDecoder(reader).bind()
     GlobalType(valueType, mutability)
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/AbstractHeapTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/AbstractHeapTypeDecoder.kt
@@ -1,0 +1,7 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.heap
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+
+internal typealias AbstractHeapTypeDecoder = (UByte) -> Result<AbstractHeapType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryAbstractHeapTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryAbstractHeapTypeDecoder.kt
@@ -1,0 +1,37 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.heap
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+
+internal fun BinaryAbstractHeapTypeDecoder(
+    encoded: UByte,
+): Result<AbstractHeapType, WasmDecodeError> = binding {
+    when (encoded) {
+        HEAP_TYPE_ARRAY -> AbstractHeapType.Array
+        HEAP_TYPE_STRUCT -> AbstractHeapType.Struct
+        HEAP_TYPE_I31 -> AbstractHeapType.I31
+        HEAP_TYPE_EQ -> AbstractHeapType.Eq
+        HEAP_TYPE_ANY -> AbstractHeapType.Any
+        HEAP_TYPE_EXTERN -> AbstractHeapType.Extern
+        HEAP_TYPE_FUNC -> AbstractHeapType.Func
+        HEAP_TYPE_NONE -> AbstractHeapType.None
+        HEAP_TYPE_NO_EXTERN -> AbstractHeapType.NoExtern
+        HEAP_TYPE_NO_FUNC -> AbstractHeapType.NoFunc
+        else -> Err(TypeDecodeError.InvalidHeapType(encoded)).bind<AbstractHeapType>()
+    }
+}
+
+internal const val HEAP_TYPE_ARRAY: UByte = 0x6Au
+internal const val HEAP_TYPE_STRUCT: UByte = 0x6Bu
+internal const val HEAP_TYPE_I31: UByte = 0x6Cu
+internal const val HEAP_TYPE_EQ: UByte = 0x6Du
+internal const val HEAP_TYPE_ANY: UByte = 0x6Eu
+internal const val HEAP_TYPE_EXTERN: UByte = 0x6Fu
+internal const val HEAP_TYPE_FUNC: UByte = 0x70u
+internal const val HEAP_TYPE_NONE: UByte = 0x71u
+internal const val HEAP_TYPE_NO_EXTERN: UByte = 0x72u
+internal const val HEAP_TYPE_NO_FUNC: UByte = 0x73u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
@@ -28,8 +28,7 @@ internal fun BinaryHeapTypeDecoder(
             abstractHeapTypeDecoder(encoded).bind()
         }
         in CONCRETE_HEAP_TYPE_RANGE -> {
-            // Not using TypeIndexDecoder here as it's stored in a signed leb s33
-            val typeIndex = Index.TypeIndex(reader.long().bind().toUInt())
+            val typeIndex = Index.TypeIndex(reader.s33().bind())
             ConcreteHeapType(typeIndex)
         }
         else -> Err(TypeDecodeError.InvalidHeapType(encoded)).bind<HeapType>()

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
@@ -29,7 +29,7 @@ internal fun BinaryHeapTypeDecoder(
         }
         in CONCRETE_HEAP_TYPE_RANGE -> {
             val typeIndex = Index.TypeIndex(reader.s33().bind())
-            ConcreteHeapType(typeIndex)
+            ConcreteHeapType.TypeIndex(typeIndex)
         }
         else -> Err(TypeDecodeError.InvalidHeapType(encoded)).bind<HeapType>()
     }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoder.kt
@@ -1,28 +1,40 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.heap
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
 import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
 internal fun BinaryHeapTypeDecoder(
     reader: WasmBinaryReader,
+): Result<HeapType, WasmDecodeError> =
+    BinaryHeapTypeDecoder(
+        reader = reader,
+        abstractHeapTypeDecoder = ::BinaryAbstractHeapTypeDecoder,
+    )
+
+internal fun BinaryHeapTypeDecoder(
+    reader: WasmBinaryReader,
+    abstractHeapTypeDecoder: AbstractHeapTypeDecoder,
 ): Result<HeapType, WasmDecodeError> = binding {
-
-    val encoded = reader.peek().ubyte().bind()
-
-    when (encoded) {
-        HEAP_TYPE_FUNC -> HeapType.Func.also { reader.ubyte() }
-        HEAP_TYPE_EXTERN -> HeapType.Extern.also { reader.ubyte() }
-        else -> {
+    when (val encoded = reader.peek().ubyte().bind()) {
+        in ABSTRACT_HEAP_TYPE_RANGE -> {
+            reader.ubyte().bind() // consume byte
+            abstractHeapTypeDecoder(encoded).bind()
+        }
+        in CONCRETE_HEAP_TYPE_RANGE -> {
             // Not using TypeIndexDecoder here as it's stored in a signed leb s33
             val typeIndex = Index.TypeIndex(reader.long().bind().toUInt())
-            HeapType.TypeIndex(typeIndex)
+            ConcreteHeapType(typeIndex)
         }
+        else -> Err(TypeDecodeError.InvalidHeapType(encoded)).bind<HeapType>()
     }
 }
 
-internal const val HEAP_TYPE_EXTERN: UByte = 0x6Fu
-internal const val HEAP_TYPE_FUNC: UByte = 0x70u
+internal val ABSTRACT_HEAP_TYPE_RANGE = HEAP_TYPE_ARRAY..HEAP_TYPE_NO_FUNC
+internal val CONCRETE_HEAP_TYPE_RANGE = 0x00u..0x7Fu // 0..127

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/number/BinaryNumberTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/number/BinaryNumberTypeDecoder.kt
@@ -9,9 +9,14 @@ import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 internal fun BinaryNumberTypeDecoder(
     encoded: UByte,
 ): Result<NumberType, TypeDecodeError.InvalidNumberType> = when (encoded) {
-    0x7F.toUByte() -> Ok(NumberType.I32)
-    0x7E.toUByte() -> Ok(NumberType.I64)
-    0x7D.toUByte() -> Ok(NumberType.F32)
-    0x7C.toUByte() -> Ok(NumberType.F64)
+    NUMBER_TYPE_I32 -> Ok(NumberType.I32)
+    NUMBER_TYPE_I64 -> Ok(NumberType.I64)
+    NUMBER_TYPE_F32 -> Ok(NumberType.F32)
+    NUMBER_TYPE_F64 -> Ok(NumberType.F64)
     else -> Err(TypeDecodeError.InvalidNumberType(encoded))
 }
+
+internal const val NUMBER_TYPE_I32: UByte = 0x7Fu
+internal const val NUMBER_TYPE_I64: UByte = 0x7Eu
+internal const val NUMBER_TYPE_F32: UByte = 0x7Du
+internal const val NUMBER_TYPE_F64: UByte = 0x7Cu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinaryRecursiveTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinaryRecursiveTypeDecoder.kt
@@ -1,0 +1,39 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinaryRecursiveTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<RecursiveType, WasmDecodeError> =
+    BinaryRecursiveTypeDecoder(
+        reader = reader,
+        subTypeDecoder = ::BinarySubTypeDecoder,
+        vectorDecoder = ::BinaryVectorDecoder,
+    )
+
+internal fun BinaryRecursiveTypeDecoder(
+    reader: WasmBinaryReader,
+    subTypeDecoder: SubTypeDecoder,
+    vectorDecoder: VectorDecoder<SubType>,
+): Result<RecursiveType, WasmDecodeError> = binding {
+    when (reader.peek().ubyte().bind()) {
+        MULTIPLE_SUBTYPES_RECURSIVE_TYPE -> {
+            reader.ubyte().bind() // consume byte
+            val subTypes = vectorDecoder(reader, subTypeDecoder).bind()
+            RecursiveType(subTypes.vector)
+        }
+        else -> {
+            val subType = subTypeDecoder(reader).bind()
+            RecursiveType(listOf(subType))
+        }
+    }
+}
+
+internal const val MULTIPLE_SUBTYPES_RECURSIVE_TYPE: UByte = 0x4Eu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoder.kt
@@ -1,0 +1,53 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryTypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.composite.BinaryCompositeTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.composite.CompositeTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal fun BinarySubTypeDecoder(
+    reader: WasmBinaryReader,
+): Result<SubType, WasmDecodeError> =
+    BinarySubTypeDecoder(
+        reader = reader,
+        typeIndexDecoder = ::BinaryTypeIndexDecoder,
+        vectorDecoder = ::BinaryVectorDecoder,
+        compositeTypeDecoder = ::BinaryCompositeTypeDecoder,
+    )
+
+internal fun BinarySubTypeDecoder(
+    reader: WasmBinaryReader,
+    typeIndexDecoder: TypeIndexDecoder,
+    vectorDecoder: VectorDecoder<Index.TypeIndex>,
+    compositeTypeDecoder: CompositeTypeDecoder,
+): Result<SubType, WasmDecodeError> = binding {
+    when (reader.peek().ubyte().bind()) {
+        OPEN_SUB_TYPE -> {
+            reader.ubyte().bind() // consume byte
+            val typeIndices = vectorDecoder(reader, typeIndexDecoder).bind()
+            val compositeType = compositeTypeDecoder(reader).bind()
+            SubType.Open(typeIndices.vector, compositeType)
+        }
+        FINAL_SUB_TYPE -> {
+            reader.ubyte().bind() // consume byte
+            val typeIndices = vectorDecoder(reader, typeIndexDecoder).bind()
+            val compositeType = compositeTypeDecoder(reader).bind()
+            SubType.Final(typeIndices.vector, compositeType)
+        }
+        else -> {
+            val compositeType = compositeTypeDecoder(reader).bind()
+            SubType.Final(emptyList(), compositeType)
+        }
+    }
+}
+
+internal const val OPEN_SUB_TYPE: UByte = 0x50u
+internal const val FINAL_SUB_TYPE: UByte = 0x4Fu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoder.kt
@@ -3,6 +3,7 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
 import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.BinaryTypeIndexDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
@@ -33,14 +34,16 @@ internal fun BinarySubTypeDecoder(
         OPEN_SUB_TYPE -> {
             reader.ubyte().bind() // consume byte
             val typeIndices = vectorDecoder(reader, typeIndexDecoder).bind()
+            val heapTypes = typeIndices.vector.map(ConcreteHeapType::TypeIndex)
             val compositeType = compositeTypeDecoder(reader).bind()
-            SubType.Open(typeIndices.vector, compositeType)
+            SubType.Open(heapTypes, compositeType)
         }
         FINAL_SUB_TYPE -> {
             reader.ubyte().bind() // consume byte
             val typeIndices = vectorDecoder(reader, typeIndexDecoder).bind()
+            val heapTypes = typeIndices.vector.map(ConcreteHeapType::TypeIndex)
             val compositeType = compositeTypeDecoder(reader).bind()
-            SubType.Final(typeIndices.vector, compositeType)
+            SubType.Final(heapTypes, compositeType)
         }
         else -> {
             val compositeType = compositeTypeDecoder(reader).bind()

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/RecursiveTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/RecursiveTypeDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias RecursiveTypeDecoder = (WasmBinaryReader) -> Result<RecursiveType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/SubTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/SubTypeDecoder.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
+
+internal typealias SubTypeDecoder = (WasmBinaryReader) -> Result<SubType, WasmDecodeError>

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/reference/BinaryReferenceTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/reference/BinaryReferenceTypeDecoder.kt
@@ -1,13 +1,12 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.reference
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.AbstractHeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.BinaryAbstractHeapTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.BinaryHeapTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
@@ -19,23 +18,21 @@ internal fun BinaryReferenceTypeDecoder(
         reader = reader,
         encoded = encoded,
         heapTypeDecoder = ::BinaryHeapTypeDecoder,
+        abstractHeapTypeDecoder = ::BinaryAbstractHeapTypeDecoder,
     )
 
 internal fun BinaryReferenceTypeDecoder(
     reader: WasmBinaryReader,
     encoded: UByte,
     heapTypeDecoder: HeapTypeDecoder,
+    abstractHeapTypeDecoder: AbstractHeapTypeDecoder,
 ): Result<ReferenceType, WasmDecodeError> = binding {
     when (encoded) {
-        REFERENCE_TYPE_FUNC -> ReferenceType.RefNull(HeapType.Func)
-        REFERENCE_TYPE_EXTERN -> ReferenceType.RefNull(HeapType.Extern)
         REFERENCE_TYPE_REF -> ReferenceType.Ref(heapTypeDecoder(reader).bind())
         REFERENCE_TYPE_REF_NULL -> ReferenceType.RefNull(heapTypeDecoder(reader).bind())
-        else -> Err(TypeDecodeError.InvalidReferenceType(encoded)).bind<ReferenceType>()
+        else -> ReferenceType.RefNull(abstractHeapTypeDecoder(encoded).bind())
     }
 }
 
 internal const val REFERENCE_TYPE_REF_NULL: UByte = 0x63u
 internal const val REFERENCE_TYPE_REF: UByte = 0x64u
-internal const val REFERENCE_TYPE_EXTERN: UByte = 0x6Fu
-internal const val REFERENCE_TYPE_FUNC: UByte = 0x70u

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/vector/BinaryVectorTypeDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/vector/BinaryVectorTypeDecoder.kt
@@ -7,8 +7,10 @@ import io.github.charlietap.chasm.ast.type.VectorType
 import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 
 internal fun BinaryVectorTypeDecoder(encoded: UByte): Result<VectorType, TypeDecodeError.InvalidVectorType> =
-    if (encoded == 0x7B.toUByte()) {
+    if (encoded == VECTOR_TYPE_128) {
         Ok(VectorType.V128)
     } else {
         Err(TypeDecodeError.InvalidVectorType(encoded))
     }
+
+internal const val VECTOR_TYPE_128: UByte = 0x7Bu

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
@@ -28,5 +28,11 @@ sealed interface InstructionDecodeError : WasmDecodeError {
     @JvmInline
     value class InvalidControlInstruction(val byte: UByte) : InstructionDecodeError
 
+    @JvmInline
+    value class InvalidPrefixedControlInstruction(val byte: UByte) : InstructionDecodeError
+
+    @JvmInline
+    value class InvalidCastFlags(val byte: UByte) : InstructionDecodeError
+
     data class InvalidPrefixInstruction(val prefix: UByte, val opcode: UInt) : InstructionDecodeError
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
@@ -14,6 +14,9 @@ sealed interface InstructionDecodeError : WasmDecodeError {
     value class InvalidReferenceInstruction(val byte: UByte) : InstructionDecodeError
 
     @JvmInline
+    value class InvalidPrefixedReferenceInstruction(val byte: UByte) : InstructionDecodeError
+
+    @JvmInline
     value class InvalidParametricInstruction(val byte: UByte) : InstructionDecodeError
 
     @JvmInline

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/TypeDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/TypeDecodeError.kt
@@ -19,6 +19,9 @@ sealed interface TypeDecodeError : WasmDecodeError {
     value class InvalidStorageType(val encoded: UByte) : TypeDecodeError
 
     @JvmInline
+    value class InvalidCompositeType(val encoded: UByte) : TypeDecodeError
+
+    @JvmInline
     value class InvalidReferenceType(val encoded: UByte) : TypeDecodeError
 
     @JvmInline

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/TypeDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/TypeDecodeError.kt
@@ -13,6 +13,12 @@ sealed interface TypeDecodeError : WasmDecodeError {
     value class InvalidHeapType(val encoded: UByte) : TypeDecodeError
 
     @JvmInline
+    value class InvalidPackedType(val encoded: UByte) : TypeDecodeError
+
+    @JvmInline
+    value class InvalidStorageType(val encoded: UByte) : TypeDecodeError
+
+    @JvmInline
     value class InvalidReferenceType(val encoded: UByte) : TypeDecodeError
 
     @JvmInline

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/SourceWasmBinaryReader.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/SourceWasmBinaryReader.kt
@@ -49,6 +49,8 @@ internal class SourceWasmBinaryReader(
 
     override fun uint(): Result<UInt, WasmDecodeError> = tryRead { unsignedByteStream.toUIntLeb128() }
 
+    override fun s33(): Result<UInt, WasmDecodeError> = tryRead { byteStream.toLongLeb128().toUInt() }
+
     override fun long(): Result<Long, WasmDecodeError> = tryRead { byteStream.toLongLeb128() }
 
     override fun float(): Result<Float, WasmDecodeError> = binding {

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/WasmBinaryReader.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/WasmBinaryReader.kt
@@ -17,6 +17,8 @@ internal interface WasmBinaryReader {
 
     fun uint(): Result<UInt, WasmDecodeError>
 
+    fun s33(): Result<UInt, WasmDecodeError>
+
     fun long(): Result<Long, WasmDecodeError>
 
     fun float(): Result<Float, WasmDecodeError>

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoderTest.kt
@@ -11,7 +11,6 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.REFERENCE_TYPE
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VECTOR_TYPE_RANGE
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
-import io.github.charlietap.chasm.decoder.wasm.ext.toSignedLeb128
 import io.github.charlietap.chasm.decoder.wasm.fixture.ioError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
@@ -73,14 +72,14 @@ class BinaryBlockTypeDecoderTest {
     fun `can decode signed type index block type`() {
 
         val expectedInt = 117u
-        val longReader = {
-            Ok(expectedInt.toLong())
-        }
 
         val peekReader = FakeUByteReader {
-            Ok(expectedInt.toInt().toSignedLeb128().first().toUByte())
+            Ok(0x00u)
         }
-        val reader = FakeWasmBinaryReader(fakePeekReader = { peekReader }, fakeLongReader = longReader)
+        val reader = FakeWasmBinaryReader(
+            fakePeekReader = { peekReader },
+            fakeS33Reader = { Ok(expectedInt) },
+        )
 
         val expected = Ok(BlockType.SignedTypeIndex(Index.TypeIndex(expectedInt)))
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryBlockTypeDecoderTest.kt
@@ -6,13 +6,9 @@ import io.github.charlietap.chasm.ast.instruction.ControlInstruction.BlockType
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ValueType
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_NUMBER_F32
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_NUMBER_F64
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_NUMBER_I32
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_NUMBER_I64
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_EXTERNREF
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_FUNCREF
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_VECTOR_V128
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.NUMBER_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.REFERENCE_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VECTOR_TYPE_RANGE
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.ext.toSignedLeb128
@@ -50,18 +46,13 @@ class BinaryBlockTypeDecoderTest {
     @Test
     fun `can decode value type block type`() {
 
-        val valueTypes = sequenceOf(
-            VALUE_TYPE_NUMBER_I32,
-            VALUE_TYPE_NUMBER_I64,
-            VALUE_TYPE_NUMBER_F32,
-            VALUE_TYPE_NUMBER_F64,
-            VALUE_TYPE_VECTOR_V128,
-            VALUE_TYPE_REFERENCE_FUNCREF,
-            VALUE_TYPE_REFERENCE_EXTERNREF,
-        )
+        val valueTypes = NUMBER_TYPE_RANGE.asSequence() +
+            VECTOR_TYPE_RANGE.asSequence() +
+            REFERENCE_TYPE_RANGE.asSequence()
+
         val iter = valueTypes.iterator()
         val peekReader = FakeUByteReader {
-            Ok(iter.next())
+            Ok(iter.next().toUByte())
         }
         val reader = FakeWasmBinaryReader(fakePeekReader = { peekReader })
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryCastFlagsDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryCastFlagsDecoderTest.kt
@@ -1,0 +1,30 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryCastFlagsDecoderTest {
+
+    @Test
+    fun `can decode an encoded cast flags`() {
+
+        val castFlagsMap = mapOf(
+            NON_NULL_BOTH_CAST_FLAGS to CastFlags(Nullability.NON_NULL, Nullability.NON_NULL),
+            NULL_TO_NON_NULL_CAST_FLAGS to CastFlags(Nullability.NULL, Nullability.NON_NULL),
+            NON_NULL_TO_NULL_CAST_FLAGS to CastFlags(Nullability.NON_NULL, Nullability.NULL),
+            NULL_BOTH_CAST_FLAGS to CastFlags(Nullability.NULL, Nullability.NULL),
+        )
+
+        castFlagsMap.forEach { (castFlagByte, castFlags) ->
+
+            val reader = FakeUByteReader { Ok(castFlagByte) }
+            val expected = Ok(castFlags)
+
+            val actual = BinaryCastFlagsDecoder(reader)
+
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoderTest.kt
@@ -33,6 +33,7 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.instruction.prefixedControlInstruction
 import io.github.charlietap.chasm.fixture.module.labelIndex
 import io.github.charlietap.chasm.fixture.module.typeIndex
 import kotlin.test.Test
@@ -91,6 +92,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -124,6 +126,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -156,6 +159,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -183,6 +187,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = labelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -210,6 +215,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = labelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -242,6 +248,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = labelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = vectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -280,6 +287,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -312,6 +320,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = tableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -339,6 +348,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -371,6 +381,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = tableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -398,6 +409,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -425,6 +437,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = neverLabelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -452,6 +465,7 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = labelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -479,6 +493,36 @@ class BinaryControlInstructionDecoderTest {
             labelIndexDecoder = labelIndexDecoder,
             tableIndexDecoder = neverTableIndexDecoder,
             vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = neverPrefixedControlInstructionDecoder,
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `delegates prefixed control instructions to the prefixed decoder`() {
+
+        val opcode = PREFIXED_CONTROL_INSTRUCTION
+
+        val prefixedControlInstruction = prefixedControlInstruction()
+        val prefixedControlInstructionDecoder: PrefixedControlInstructionDecoder = { _ ->
+            Ok(prefixedControlInstruction)
+        }
+
+        val expected = Ok(prefixedControlInstruction)
+
+        val actual = BinaryControlInstructionDecoder(
+            reader = FakeWasmBinaryReader(),
+            opcode = opcode,
+            blockTypeDecoder = neverBlockTypeDecoder,
+            instructionBlockDecoder = neverInstructionBlockDecoder,
+            ifDecoder = neverIfDecoder,
+            functionIndexDecoder = neverFunctionIndexDecoder,
+            typeIndexDecoder = neverTypeIndexDecoder,
+            labelIndexDecoder = neverLabelIndexDecoder,
+            tableIndexDecoder = neverTableIndexDecoder,
+            vectorDecoder = neverVectorDecoder,
+            prefixedControlInstructionDecoder = prefixedControlInstructionDecoder,
         )
 
         assertEquals(expected, actual)
@@ -520,6 +564,9 @@ class BinaryControlInstructionDecoderTest {
         }
         private val neverVectorDecoder: VectorDecoder<Index.LabelIndex> = { _, _ ->
             fail("vector decoder should not run in this scenario")
+        }
+        private val neverPrefixedControlInstructionDecoder: PrefixedControlInstructionDecoder = { _ ->
+            fail("prefixed control instruction decoder should not run in this scenario")
         }
     }
 }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryControlInstructionDecoderTest.kt
@@ -33,8 +33,8 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
-import io.github.charlietap.chasm.fixture.instruction.labelIndex
-import io.github.charlietap.chasm.fixture.instruction.typeIndex
+import io.github.charlietap.chasm.fixture.module.labelIndex
+import io.github.charlietap.chasm.fixture.module.typeIndex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryPrefixedControlInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/control/BinaryPrefixedControlInstructionDecoderTest.kt
@@ -1,0 +1,93 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.control
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.instruction.ControlInstruction
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.LabelIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUIntReader
+import io.github.charlietap.chasm.fixture.module.labelIndex
+import io.github.charlietap.chasm.fixture.type.heapType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryPrefixedControlInstructionDecoderTest {
+
+    @Test
+    fun `can decode an encoded br on cast instruction`() {
+
+        val reader = FakeUIntReader { Ok(BR_ON_CAST) }
+
+        val labelIndex = labelIndex()
+        val labelIndexDecoder: LabelIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(labelIndex)
+        }
+
+        val castFlags = CastFlags(Nullability.NULL, Nullability.NON_NULL)
+        val castFlagsDecoder: CastFlagsDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(castFlags)
+        }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ControlInstruction.BrOnCast(
+            labelIndex,
+            ReferenceType.RefNull(heapType),
+            ReferenceType.Ref(heapType),
+        )
+
+        val actual = BinaryPrefixedControlInstructionDecoder(
+            reader = reader,
+            labelIndexDecoder = labelIndexDecoder,
+            castFlagsDecoder = castFlagsDecoder,
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded br on cast fail instruction`() {
+
+        val reader = FakeUIntReader { Ok(BR_ON_CAST_FAIL) }
+
+        val labelIndex = labelIndex()
+        val labelIndexDecoder: LabelIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(labelIndex)
+        }
+
+        val castFlags = CastFlags(Nullability.NULL, Nullability.NON_NULL)
+        val castFlagsDecoder: CastFlagsDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(castFlags)
+        }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ControlInstruction.BrOnCastFail(
+            labelIndex,
+            ReferenceType.RefNull(heapType),
+            ReferenceType.Ref(heapType),
+        )
+
+        val actual = BinaryPrefixedControlInstructionDecoder(
+            reader = reader,
+            labelIndexDecoder = labelIndexDecoder,
+            castFlagsDecoder = castFlagsDecoder,
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryPrefixedReferenceInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryPrefixedReferenceInstructionDecoderTest.kt
@@ -1,0 +1,734 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.instruction.reference
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.instruction.AggregateInstruction
+import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.DataIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.ElementIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.FieldIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUIntReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.module.dataIndex
+import io.github.charlietap.chasm.fixture.module.elementIndex
+import io.github.charlietap.chasm.fixture.module.fieldIndex
+import io.github.charlietap.chasm.fixture.module.typeIndex
+import io.github.charlietap.chasm.fixture.type.heapType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinaryPrefixedReferenceInstructionDecoderTest {
+
+    @Test
+    fun `can decode an encoded struct new instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_NEW) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.StructNew(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded struct new default instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_NEW_DEFAULT) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.StructNewDefault(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded struct get instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_GET) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val fieldIndex = fieldIndex()
+        val fieldIndexDecoder: FieldIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(fieldIndex)
+        }
+
+        val expected = AggregateInstruction.StructGet(typeIndex, fieldIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder,
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded struct get signed instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_GET_SIGNED) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val fieldIndex = fieldIndex()
+        val fieldIndexDecoder: FieldIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(fieldIndex)
+        }
+
+        val expected = AggregateInstruction.StructGetSigned(typeIndex, fieldIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder,
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded struct get unsigned instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_GET_UNSIGNED) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val fieldIndex = fieldIndex()
+        val fieldIndexDecoder: FieldIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(fieldIndex)
+        }
+
+        val expected = AggregateInstruction.StructGetUnsigned(typeIndex, fieldIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder,
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded struct set instruction`() {
+
+        val reader = FakeUIntReader { Ok(STRUCT_SET) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val fieldIndex = fieldIndex()
+        val fieldIndexDecoder: FieldIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(fieldIndex)
+        }
+
+        val expected = AggregateInstruction.StructSet(typeIndex, fieldIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder,
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array new instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_NEW) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayNew(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array new default instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_NEW_DEFAULT) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayNewDefault(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array new fixed instruction`() {
+
+        val opcode = ARRAY_NEW_FIXED
+        val size = 117u
+        val uInts = sequenceOf(opcode, size).iterator()
+        val reader = FakeWasmBinaryReader(
+            fakeUIntReader = { Ok(uInts.next()) },
+        )
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayNewFixed(typeIndex, size)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array new data instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_NEW_DATA) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val dataIndex = dataIndex()
+        val dataIndexDecoder: DataIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(dataIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayNewData(typeIndex, dataIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder,
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array new element instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_NEW_ELEMENT) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val elementIndex = elementIndex()
+        val elementIndexDecoder: ElementIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(elementIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayNewElement(typeIndex, elementIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder,
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array get instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_GET) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayGet(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array get signed instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_GET_SIGNED) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayGetSigned(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array get unsigned instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_GET_UNSIGNED) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayGetUnsigned(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array set instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_SET) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArraySet(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array len instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_LEN) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayLen
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array fill instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_FILL) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayFill(typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array copy instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_COPY) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayCopy(typeIndex, typeIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array init data instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_INIT_DATA) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val dataIndex = dataIndex()
+        val dataIndexDecoder: DataIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(dataIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayInitData(typeIndex, dataIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder,
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded array init element instruction`() {
+
+        val reader = FakeUIntReader { Ok(ARRAY_INIT_ELEMENT) }
+
+        val typeIndex = typeIndex()
+        val typeIndexDecoder: TypeIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(typeIndex)
+        }
+
+        val elementIndex = elementIndex()
+        val elementIndexDecoder: ElementIndexDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(elementIndex)
+        }
+
+        val expected = AggregateInstruction.ArrayInitElement(typeIndex, elementIndex)
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder,
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder,
+            heapTypeDecoder = heapTypeDecoder(),
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded ref test instruction`() {
+
+        val reader = FakeUIntReader { Ok(REF_TEST) }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ReferenceInstruction.RefTest(
+            ReferenceType.Ref(heapType),
+        )
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder(),
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded ref test instruction with a null ref`() {
+
+        val reader = FakeUIntReader { Ok(REF_TEST_NULL) }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ReferenceInstruction.RefTest(
+            ReferenceType.RefNull(heapType),
+        )
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder(),
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded ref cast instruction`() {
+
+        val reader = FakeUIntReader { Ok(REF_CAST) }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ReferenceInstruction.RefCast(
+            ReferenceType.Ref(heapType),
+        )
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder(),
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded ref cast instruction with a null ref`() {
+
+        val reader = FakeUIntReader { Ok(REF_CAST_NULL) }
+
+        val heapType = heapType()
+        val heapTypeDecoder: HeapTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(heapType)
+        }
+
+        val expected = ReferenceInstruction.RefCast(
+            ReferenceType.RefNull(heapType),
+        )
+
+        val actual = BinaryPrefixedReferenceInstructionDecoder(
+            reader = reader,
+            dataIndexDecoder = dataIndexDecoder(),
+            elementIndexDecoder = elementIndexDecoder(),
+            fieldIndexDecoder = fieldIndexDecoder(),
+            typeIndexDecoder = typeIndexDecoder(),
+            heapTypeDecoder = heapTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded aggregate instruction`() {
+
+        val aggregateInstructionMap = mapOf(
+            ANY_CONVERT_EXTERN to AggregateInstruction.AnyConvertExtern,
+            EXTERN_CONVERT_ANY to AggregateInstruction.ExternConvertAny,
+            REF_I31 to AggregateInstruction.RefI31,
+            I31_GET_SIGNED to AggregateInstruction.I31GetSigned,
+            I31_GET_UNSIGNED to AggregateInstruction.I31GetUnsigned,
+        )
+
+        aggregateInstructionMap.forEach { (instructionOp, expected) ->
+            val reader = FakeUIntReader { Ok(instructionOp) }
+
+            val actual = BinaryPrefixedReferenceInstructionDecoder(
+                reader = reader,
+                dataIndexDecoder = dataIndexDecoder(),
+                elementIndexDecoder = elementIndexDecoder(),
+                fieldIndexDecoder = fieldIndexDecoder(),
+                typeIndexDecoder = typeIndexDecoder(),
+                heapTypeDecoder = heapTypeDecoder(),
+            )
+
+            assertEquals(Ok(expected), actual)
+        }
+    }
+
+    companion object {
+        private fun dataIndexDecoder(): DataIndexDecoder = { _ ->
+            fail("DataIndexDecoder should not be called in this scenario")
+        }
+
+        private fun elementIndexDecoder(): ElementIndexDecoder = { _ ->
+            fail("ElementIndexDecoder should not be called in this scenario")
+        }
+
+        private fun fieldIndexDecoder(): FieldIndexDecoder = { _ ->
+            fail("FieldIndexDecoder should not be called in this scenario")
+        }
+
+        private fun typeIndexDecoder(): TypeIndexDecoder = { _ ->
+            fail("TypeIndexDecoder should not be called in this scenario")
+        }
+
+        private fun heapTypeDecoder(): HeapTypeDecoder = { _ ->
+            fail("HeapTypeDecoder should not be called in this scenario")
+        }
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryReferenceInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryReferenceInstructionDecoderTest.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_AS_NON_NULL
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_FUNC
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_ISNULL
@@ -29,9 +29,9 @@ class BinaryReferenceInstructionDecoderTest {
         }
         val heapTypeDecoder: HeapTypeDecoder = { _reader ->
             assertEquals(reader, _reader)
-            Ok(HeapType.Func)
+            Ok(AbstractHeapType.Func)
         }
-        val expected = Ok(ReferenceInstruction.RefNull(HeapType.Func))
+        val expected = Ok(ReferenceInstruction.RefNull(AbstractHeapType.Func))
 
         val actual = BinaryReferenceInstructionDecoder(reader, opcode, heapTypeDecoder)
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryReferenceInstructionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/reference/BinaryReferenceInstructionDecoderTest.kt
@@ -5,18 +5,16 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
-import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_AS_NON_NULL
-import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_FUNC
-import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_ISNULL
-import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.REF_NULL
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.numeric.BinaryNumericInstructionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.InstructionDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUIntReader
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.instruction.prefixedReferenceInstruction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class BinaryReferenceInstructionDecoderTest {
 
@@ -33,7 +31,12 @@ class BinaryReferenceInstructionDecoderTest {
         }
         val expected = Ok(ReferenceInstruction.RefNull(AbstractHeapType.Func))
 
-        val actual = BinaryReferenceInstructionDecoder(reader, opcode, heapTypeDecoder)
+        val actual = BinaryReferenceInstructionDecoder(
+            reader,
+            opcode,
+            heapTypeDecoder,
+            prefixedReferenceInstructionDecoder(),
+        )
 
         assertEquals(expected, actual)
     }
@@ -64,12 +67,42 @@ class BinaryReferenceInstructionDecoderTest {
     }
 
     @Test
+    fun `can decode the REF_EQ instruction`() {
+
+        val opcode = REF_EQ
+        val expected = Ok(ReferenceInstruction.RefEq)
+
+        val actual = BinaryReferenceInstructionDecoder(FakeWasmBinaryReader(), opcode)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `can decode the REF_AS_NOT_NULL instruction`() {
 
         val opcode = REF_AS_NON_NULL
         val expected = Ok(ReferenceInstruction.RefAsNonNull)
 
         val actual = BinaryReferenceInstructionDecoder(FakeWasmBinaryReader(), opcode)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `delegates prefixed instructions to the prefixed decoder`() {
+
+        val opcode = PREFIXED_REFERENCE_INSTRUCTION
+
+        val reader = FakeWasmBinaryReader()
+
+        val prefixedReferenceInstruction = prefixedReferenceInstruction()
+        val prefixedDecoder: PrefixedReferenceInstructionDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(prefixedReferenceInstruction)
+        }
+        val expected = Ok(prefixedReferenceInstruction)
+
+        val actual = BinaryReferenceInstructionDecoder(reader, opcode, heapTypeDecoder(), prefixedDecoder)
 
         assertEquals(expected, actual)
     }
@@ -84,5 +117,15 @@ class BinaryReferenceInstructionDecoderTest {
         val actual = BinaryNumericInstructionDecoder(FakeWasmBinaryReader(), opcode)
 
         assertEquals(expected, actual)
+    }
+
+    companion object {
+        private fun heapTypeDecoder(): HeapTypeDecoder = { _ ->
+            fail("HeapTypeDecoder should not be called in this scenario")
+        }
+
+        private fun prefixedReferenceInstructionDecoder(): PrefixedReferenceInstructionDecoder = { _ ->
+            fail("PrefixedReferenceInstruction should not be called in this scenario")
+        }
     }
 }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSectionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSectionDecoderTest.kt
@@ -3,7 +3,7 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.section.element
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.ElementSegment
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
@@ -21,7 +21,7 @@ class BinaryElementSectionDecoderTest {
 
         val segment = ElementSegment(
             idx = Index.ElementIndex(0u),
-            type = ReferenceType.RefNull(HeapType.Func),
+            type = ReferenceType.RefNull(AbstractHeapType.Func),
             initExpressions = emptyList(),
             mode = ElementSegment.Mode.Passive,
         )

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoderTest.kt
@@ -6,13 +6,13 @@ import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.ast.module.ElementSegment
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.ExpressionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.FunctionIndexDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TableIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.reference.REFERENCE_TYPE_REF_NULL
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.reference.ReferenceTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VALUE_TYPE_REFERENCE_REF_NULL
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
@@ -46,7 +46,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 listOf(
                     Expression(ReferenceInstruction.RefFunc(functionIndex1)),
                     Expression(ReferenceInstruction.RefFunc(functionIndex2)),
@@ -96,7 +96,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 listOf(
                     Expression(ReferenceInstruction.RefFunc(functionIndex1)),
                     Expression(ReferenceInstruction.RefFunc(functionIndex2)),
@@ -148,7 +148,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 listOf(
                     Expression(ReferenceInstruction.RefFunc(functionIndex1)),
                     Expression(ReferenceInstruction.RefFunc(functionIndex2)),
@@ -207,7 +207,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 listOf(
                     Expression(ReferenceInstruction.RefFunc(functionIndex1)),
                     Expression(ReferenceInstruction.RefFunc(functionIndex2)),
@@ -260,7 +260,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 emptyList(),
                 mode,
             ),
@@ -293,7 +293,7 @@ class BinaryElementSegmentDecoderTest {
     fun `can decode a passive many expressions element segment`() {
 
         val segmentId = SEGMENT_TYPE_PASSIVE_MANY_EXPRESSIONS
-        val opcode = VALUE_TYPE_REFERENCE_REF_NULL
+        val opcode = REFERENCE_TYPE_REF_NULL
 
         val segmentReader: () -> Result<UInt, WasmDecodeError> = {
             Ok(segmentId)
@@ -314,7 +314,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 emptyList(),
                 mode,
             ),
@@ -323,7 +323,7 @@ class BinaryElementSegmentDecoderTest {
         val referenceTypeDecoder: ReferenceTypeDecoder = { _reader, _opcode ->
             assertEquals(reader, _reader)
             assertEquals(opcode, _opcode)
-            Ok(ReferenceType.RefNull(HeapType.Func))
+            Ok(ReferenceType.RefNull(AbstractHeapType.Func))
         }
 
         val vectorExpressionDecoder: VectorDecoder<Expression> = { _, _ ->
@@ -349,7 +349,7 @@ class BinaryElementSegmentDecoderTest {
     fun `can decode an active with table index element segment`() {
 
         val segmentId = SEGMENT_TYPE_ACTIVE_W_TABLEIDX
-        val opcode = VALUE_TYPE_REFERENCE_REF_NULL
+        val opcode = REFERENCE_TYPE_REF_NULL
 
         val segmentReader: () -> Result<UInt, WasmDecodeError> = {
             Ok(segmentId)
@@ -372,7 +372,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 emptyList(),
                 mode,
             ),
@@ -385,7 +385,7 @@ class BinaryElementSegmentDecoderTest {
         val referenceTypeDecoder: ReferenceTypeDecoder = { _reader, _opcode ->
             assertEquals(reader, _reader)
             assertEquals(opcode, _opcode)
-            Ok(ReferenceType.RefNull(HeapType.Func))
+            Ok(ReferenceType.RefNull(AbstractHeapType.Func))
         }
 
         val tableIndexDecoder: TableIndexDecoder = { _ ->
@@ -415,7 +415,7 @@ class BinaryElementSegmentDecoderTest {
     fun `can decode a declarative many expressions element segment`() {
 
         val segmentId = SEGMENT_TYPE_DECLARATIVE_MANY_EXPRESSIONS
-        val opcode = VALUE_TYPE_REFERENCE_REF_NULL
+        val opcode = REFERENCE_TYPE_REF_NULL
 
         val segmentReader: () -> Result<UInt, WasmDecodeError> = {
             Ok(segmentId)
@@ -436,7 +436,7 @@ class BinaryElementSegmentDecoderTest {
         val expected = Ok(
             ElementSegment(
                 elementIndex,
-                ReferenceType.RefNull(HeapType.Func),
+                ReferenceType.RefNull(AbstractHeapType.Func),
                 emptyList(),
                 mode,
             ),
@@ -445,7 +445,7 @@ class BinaryElementSegmentDecoderTest {
         val referenceTypeDecoder: ReferenceTypeDecoder = { _reader, _opcode ->
             assertEquals(reader, _reader)
             assertEquals(opcode, _opcode)
-            Ok(ReferenceType.RefNull(HeapType.Func))
+            Ok(ReferenceType.RefNull(AbstractHeapType.Func))
         }
 
         val vectorExpressionDecoder: VectorDecoder<Expression> = { _, _ ->

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/element/BinaryElementSegmentDecoderTest.kt
@@ -20,7 +20,7 @@ import io.github.charlietap.chasm.decoder.wasm.fixture.ioError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUIntReader
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.decoder.wasm.reader.IOErrorWasmFileReader
-import io.github.charlietap.chasm.fixture.instruction.functionIndex
+import io.github.charlietap.chasm.fixture.module.functionIndex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/global/BinaryGlobalDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/global/BinaryGlobalDecoderTest.kt
@@ -4,12 +4,10 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.module.Global
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.GlobalType
-import io.github.charlietap.chasm.ast.type.NumberType
-import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.ExpressionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.global.GlobalTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.globalType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -18,10 +16,7 @@ class BinaryGlobalDecoderTest {
     @Test
     fun `can decode an encoded global`() {
 
-        val globalType = GlobalType(
-            valueType = ValueType.Number(NumberType.I32),
-            mutability = GlobalType.Mutability.Var,
-        )
+        val globalType = globalType()
         val globalTypeDecoder: GlobalTypeDecoder = { _ ->
             Ok(globalType)
         }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/global/BinaryGlobalSectionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/global/BinaryGlobalSectionDecoderTest.kt
@@ -4,14 +4,12 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.module.Global
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.GlobalType
-import io.github.charlietap.chasm.ast.type.NumberType
-import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.decoder.wasm.section.GlobalSection
 import io.github.charlietap.chasm.decoder.wasm.section.SectionSize
+import io.github.charlietap.chasm.fixture.type.globalType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -22,12 +20,12 @@ class BinaryGlobalSectionDecoderTest {
 
         val global1 = Global(
             idx = Index.GlobalIndex(0u),
-            type = GlobalType(ValueType.Number(NumberType.I32), GlobalType.Mutability.Var),
+            type = globalType(),
             initExpression = Expression(),
         )
         val global2 = Global(
             idx = Index.GlobalIndex(1u),
-            type = GlobalType(ValueType.Number(NumberType.I32), GlobalType.Mutability.Var),
+            type = globalType(),
             initExpression = Expression(),
         )
         val expected = Ok(GlobalSection(listOf(global1, global2)))

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/import/BinaryImportDescriptorDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/import/BinaryImportDescriptorDecoderTest.kt
@@ -3,8 +3,8 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.section.import
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Import
 import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.GlobalType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
 import io.github.charlietap.chasm.ast.type.NumberType
@@ -56,7 +56,7 @@ class BinaryImportDescriptorDecoderTest {
 
         val descriptor = IMPORT_DESCRIPTOR_TYPE_TABLE
 
-        val tableType = TableType(ReferenceType.RefNull(HeapType.Func), Limits(117u))
+        val tableType = TableType(ReferenceType.RefNull(AbstractHeapType.Func), Limits(117u))
         val expected = Ok(Import.Descriptor.Table(tableType))
 
         val reader = FakeUByteReader {

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/import/BinaryImportDescriptorDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/import/BinaryImportDescriptorDecoderTest.kt
@@ -4,13 +4,10 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Import
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
-import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
-import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.TableType
-import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.global.GlobalTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.memory.MemoryTypeDecoder
@@ -18,6 +15,7 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.type.table.TableTypeDecod
 import io.github.charlietap.chasm.decoder.wasm.fixture.ioError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
 import io.github.charlietap.chasm.decoder.wasm.reader.IOErrorWasmFileReader
+import io.github.charlietap.chasm.fixture.type.globalType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -110,7 +108,7 @@ class BinaryImportDescriptorDecoderTest {
 
         val descriptor = IMPORT_DESCRIPTOR_TYPE_GLOBAL
 
-        val globalType = GlobalType(ValueType.Number(NumberType.I32), GlobalType.Mutability.Var)
+        val globalType = globalType()
         val expected = Ok(Import.Descriptor.Global(globalType))
 
         val reader = FakeUByteReader {

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/BinaryIndexDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/index/BinaryIndexDecoderTest.kt
@@ -154,6 +154,20 @@ class BinaryIndexDecoderTest {
     }
 
     @Test
+    fun `can decode an encoded field index`() {
+
+        val intReader: () -> Result<UInt, WasmDecodeError> = {
+            Ok(32u)
+        }
+        val reader = FakeWasmBinaryReader(fakeUIntReader = intReader)
+
+        val expected = Ok(Index.FieldIndex(32u))
+        val actual = BinaryFieldIndexDecoder(reader)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `returns io error when read fails`() {
 
         val err = ioError()

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/table/BinaryTableDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/table/BinaryTableDecoderTest.kt
@@ -10,8 +10,8 @@ import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.fixture.instruction.expression
-import io.github.charlietap.chasm.fixture.instruction.tableIndex
 import io.github.charlietap.chasm.fixture.module.table
+import io.github.charlietap.chasm.fixture.module.tableIndex
 import io.github.charlietap.chasm.fixture.type.tableType
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/table/BinaryTableSectionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/table/BinaryTableSectionDecoderTest.kt
@@ -4,15 +4,12 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Table
-import io.github.charlietap.chasm.ast.type.HeapType
-import io.github.charlietap.chasm.ast.type.Limits
-import io.github.charlietap.chasm.ast.type.ReferenceType
-import io.github.charlietap.chasm.ast.type.TableType
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorLength
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorLengthDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.decoder.wasm.section.SectionSize
 import io.github.charlietap.chasm.decoder.wasm.section.TableSection
+import io.github.charlietap.chasm.fixture.type.tableType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -22,9 +19,7 @@ class BinaryTableSectionDecoderTest {
     fun `can decode an encoded custom section`() {
 
         val reader = FakeWasmBinaryReader()
-        val limits = Limits(117u, 121u)
-        val refType = ReferenceType.RefNull(HeapType.Func)
-        val tableType = TableType(refType, limits)
+        val tableType = tableType()
         val table = Table(Index.TableIndex(0u), tableType, Expression.EMPTY)
         val expected = Ok(TableSection(listOf(table)))
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/type/BinaryTypeSectionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/type/BinaryTypeSectionDecoderTest.kt
@@ -3,17 +3,13 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.section.type
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Type
-import io.github.charlietap.chasm.ast.type.FunctionType
-import io.github.charlietap.chasm.ast.type.NumberType
-import io.github.charlietap.chasm.ast.type.ResultType
-import io.github.charlietap.chasm.ast.type.ValueType
-import io.github.charlietap.chasm.ast.type.VectorType
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.FunctionTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive.RecursiveTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorLength
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorLengthDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.decoder.wasm.section.SectionSize
 import io.github.charlietap.chasm.decoder.wasm.section.TypeSection
+import io.github.charlietap.chasm.fixture.type.recursiveType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,34 +19,21 @@ class BinaryTypeSectionDecoderTest {
     fun `can decode an encoded type section`() {
 
         val sectionSize = SectionSize(14u)
-        val params = ResultType(
-            listOf(
-                ValueType.Vector(VectorType.V128),
-                ValueType.Number(NumberType.I32),
-            ),
-        )
-
-        val results = ResultType(
-            listOf(
-                ValueType.Vector(VectorType.V128),
-                ValueType.Number(NumberType.I64),
-            ),
-        )
-        val functionType = FunctionType(params, results)
 
         val vectorLengthDecoder: VectorLengthDecoder = {
             Ok(VectorLength(2u))
         }
-        val functionTypeDecoder: FunctionTypeDecoder = {
-            Ok(functionType)
+        val recursiveType = recursiveType()
+        val recursiveTypeDecoder: RecursiveTypeDecoder = {
+            Ok(recursiveType)
         }
-        val decoder = BinaryTypeSectionDecoder(vectorLengthDecoder, functionTypeDecoder)
+        val decoder = BinaryTypeSectionDecoder(vectorLengthDecoder, recursiveTypeDecoder)
 
         val expected = Ok(
             TypeSection(
                 listOf(
-                    Type(Index.TypeIndex(0u), functionType),
-                    Type(Index.TypeIndex(1u), functionType),
+                    Type(Index.TypeIndex(0u), recursiveType),
+                    Type(Index.TypeIndex(1u), recursiveType),
                 ),
             ),
         )

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/BinaryMutabilityDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/BinaryMutabilityDecoderTest.kt
@@ -1,0 +1,54 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.Mutability
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryMutabilityDecoderTest {
+
+    @Test
+    fun `can decode an encoded const mutability`() {
+
+        val reader = FakeUByteReader {
+            Ok(CONST_MUTABILITY)
+        }
+
+        val expected = Ok(Mutability.Const)
+
+        val actual = BinaryMutabilityDecoder(reader)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `can decode an encoded var mutability`() {
+
+        val reader = FakeUByteReader {
+            Ok(VAR_MUTABILITY)
+        }
+
+        val expected = Ok(Mutability.Var)
+
+        val actual = BinaryMutabilityDecoder(reader)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns an InvalidMutability error unrecognised byte is encountered`() {
+
+        val reader = FakeUByteReader {
+            Ok(UByte.MAX_VALUE)
+        }
+
+        val expected = Err(TypeDecodeError.UnknownMutabilityFlag(UByte.MAX_VALUE))
+
+        val actual = BinaryMutabilityDecoder(reader)
+
+        assertEquals(expected, actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoderTest.kt
@@ -1,7 +1,7 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.ArrayType
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.fixture.type.fieldType
 import kotlin.test.Test
@@ -20,7 +20,7 @@ class BinaryArrayTypeDecoderTest {
             Ok(fieldType)
         }
 
-        val expected = Ok(CompositeType.Array(fieldType))
+        val expected = Ok(ArrayType(fieldType))
 
         val actual = BinaryArrayTypeDecoder(
             reader,

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryArrayTypeDecoderTest.kt
@@ -1,0 +1,32 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.fieldType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryArrayTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded array type`() {
+
+        val reader = FakeWasmBinaryReader()
+
+        val fieldType = fieldType()
+        val fieldTypeDecoder: FieldTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(fieldType)
+        }
+
+        val expected = Ok(CompositeType.Array(fieldType))
+
+        val actual = BinaryArrayTypeDecoder(
+            reader,
+            fieldTypeDecoder,
+        )
+
+        assertEquals(expected, actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryFieldTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryFieldTypeDecoderTest.kt
@@ -1,26 +1,25 @@
-package io.github.charlietap.chasm.decoder.wasm.decoder.type.global
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.GlobalType
+import io.github.charlietap.chasm.ast.type.FieldType
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.MutabilityDecoder
-import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.fixture.type.mutability
-import io.github.charlietap.chasm.fixture.type.valueType
+import io.github.charlietap.chasm.fixture.type.storageType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class BinaryGlobalTypeDecoderTest {
+class BinaryFieldTypeDecoderTest {
 
     @Test
-    fun `can decode an encoded global type`() {
+    fun `can decode an encoded field type`() {
 
         val reader = FakeWasmBinaryReader()
 
-        val valueType = valueType()
-        val valueTypeDecoder: ValueTypeDecoder = { _reader ->
+        val storageType = storageType()
+        val storageTypeDecoder: StorageTypeDecoder = { _reader ->
             assertEquals(reader, _reader)
-            Ok(valueType)
+            Ok(storageType)
         }
 
         val mutability = mutability()
@@ -29,11 +28,11 @@ class BinaryGlobalTypeDecoderTest {
             Ok(mutability)
         }
 
-        val expected = Ok(GlobalType(valueType, mutability))
+        val expected = Ok(FieldType(storageType, mutability))
 
-        val actual = BinaryGlobalTypeDecoder(
+        val actual = BinaryFieldTypeDecoder(
             reader,
-            valueTypeDecoder,
+            storageTypeDecoder,
             mutabilityDecoder,
         )
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryPackedTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryPackedTypeDecoderTest.kt
@@ -1,0 +1,35 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.PackedType
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryPackedTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded abstract heap type`() {
+
+        val packedTypes = mapOf(
+            PACKED_TYPE_I8 to PackedType.I8,
+            PACKED_TYPE_I16 to PackedType.I16,
+        )
+
+        packedTypes.forEach { (packedTypeByte, packedType) ->
+            val actual = BinaryPackedTypeDecoder(FakeUByteReader { Ok(packedTypeByte) })
+            assertEquals(Ok(packedType), actual)
+        }
+    }
+
+    @Test
+    fun `throws an InvalidPackedType error when byte is unrecognised`() {
+
+        val byte: UByte = 0x00u
+
+        val actual = BinaryPackedTypeDecoder(FakeUByteReader { Ok(byte) })
+        assertEquals(Err(TypeDecodeError.InvalidPackedType(byte)), actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStorageTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStorageTypeDecoderTest.kt
@@ -1,0 +1,89 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.NUMBER_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.REFERENCE_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.VECTOR_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.value.ValueTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.packedType
+import io.github.charlietap.chasm.fixture.type.valueType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinaryStorageTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded value type`() {
+
+        val valueTypes = NUMBER_TYPE_RANGE.asSequence() +
+            VECTOR_TYPE_RANGE.asSequence() +
+            REFERENCE_TYPE_RANGE.asSequence()
+
+        val iter = valueTypes.iterator()
+        val peekReader = FakeUByteReader {
+            Ok(iter.next().toUByte())
+        }
+        val reader = FakeWasmBinaryReader(fakePeekReader = { peekReader })
+
+        val packedTypeDecoder: PackedTypeDecoder = { _ ->
+            fail("PackedTypeDecoder should not be called in this scenario")
+        }
+
+        val expectedValueType = valueType()
+        val valueTypeDecoder: ValueTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(expectedValueType)
+        }
+
+        val expectedStorageType = StorageType.Value(expectedValueType)
+
+        val actual = BinaryStorageTypeDecoder(reader, packedTypeDecoder, valueTypeDecoder)
+
+        assertEquals(Ok(expectedStorageType), actual)
+    }
+
+    @Test
+    fun `can decode an encoded packed type`() {
+
+        val packedTypes = PACKED_TYPE_RANGE.asSequence()
+
+        val iter = packedTypes.iterator()
+        val peekReader = FakeUByteReader {
+            Ok(iter.next().toUByte())
+        }
+        val reader = FakeWasmBinaryReader(fakePeekReader = { peekReader })
+
+        val expectedPackedType = packedType()
+        val packedTypeDecoder: PackedTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(expectedPackedType)
+        }
+
+        val valueTypeDecoder: ValueTypeDecoder = { _ ->
+            fail("ValueTypeDecoder should not be called in this scenario")
+        }
+
+        val expectedStorageType = StorageType.Packed(expectedPackedType)
+
+        val actual = BinaryStorageTypeDecoder(reader, packedTypeDecoder, valueTypeDecoder)
+
+        assertEquals(Ok(expectedStorageType), actual)
+    }
+
+    @Test
+    fun `throws an InvalidStorageType error when byte is unrecognised`() {
+
+        val byte: UByte = 0x00u
+
+        val peekReader = FakeUByteReader { Ok(byte) }
+
+        val actual = BinaryStorageTypeDecoder(FakeWasmBinaryReader(fakePeekReader = { peekReader }))
+        assertEquals(Err(TypeDecodeError.InvalidStorageType(byte)), actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoderTest.kt
@@ -1,0 +1,43 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.fieldType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinaryStructTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded struct type`() {
+
+        val reader = FakeWasmBinaryReader()
+
+        val fieldType = fieldType()
+        val fieldTypeDecoder: FieldTypeDecoder = { _ ->
+            fail("Field type decoder should not be called directly in this scenario")
+        }
+
+        val fieldTypes = listOf(fieldType)
+        val vectorDecoder: VectorDecoder<FieldType> = { _reader, _subdecoder ->
+            assertEquals(reader, _reader)
+            assertEquals(fieldTypeDecoder, _subdecoder)
+            Ok(Vector(fieldTypes))
+        }
+
+        val expected = Ok(CompositeType.Struct(fieldTypes))
+
+        val actual = BinaryStructTypeDecoder(
+            reader,
+            fieldTypeDecoder,
+            vectorDecoder,
+        )
+
+        assertEquals(expected, actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/aggregate/BinaryStructTypeDecoderTest.kt
@@ -1,8 +1,8 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate
 
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StructType
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
@@ -30,7 +30,7 @@ class BinaryStructTypeDecoderTest {
             Ok(Vector(fieldTypes))
         }
 
-        val expected = Ok(CompositeType.Struct(fieldTypes))
+        val expected = Ok(StructType(fieldTypes))
 
         val actual = BinaryStructTypeDecoder(
             reader,

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/BinaryCompositeTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/composite/BinaryCompositeTypeDecoderTest.kt
@@ -1,0 +1,100 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.composite
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.ArrayTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.aggregate.StructTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.function.FunctionTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import io.github.charlietap.chasm.fixture.type.arrayType
+import io.github.charlietap.chasm.fixture.type.functionType
+import io.github.charlietap.chasm.fixture.type.structType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinaryCompositeTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded composite array type`() {
+
+        val reader = FakeUByteReader { Ok(ARRAY_COMPOSITE_TYPE) }
+
+        val arrayType = arrayType()
+        val arrayTypeDecoder: ArrayTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(arrayType)
+        }
+
+        val expected = Ok(CompositeType.Array(arrayType))
+
+        val actual = BinaryCompositeTypeDecoder(
+            reader,
+            functionTypeDecoder(),
+            structTypeDecoder(),
+            arrayTypeDecoder,
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `can decode an encoded composite function type`() {
+
+        val reader = FakeUByteReader { Ok(FUNCTION_COMPOSITE_TYPE) }
+
+        val functionType = functionType()
+        val functionTypeDecoder: FunctionTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(functionType)
+        }
+
+        val expected = Ok(CompositeType.Function(functionType))
+
+        val actual = BinaryCompositeTypeDecoder(
+            reader,
+            functionTypeDecoder,
+            structTypeDecoder(),
+            arrayTypeDecoder(),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `can decode an encoded composite struct type`() {
+
+        val reader = FakeUByteReader { Ok(STRUCT_COMPOSITE_TYPE) }
+
+        val structType = structType()
+        val structTypeDecoder: StructTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(structType)
+        }
+
+        val expected = Ok(CompositeType.Struct(structType))
+
+        val actual = BinaryCompositeTypeDecoder(
+            reader,
+            functionTypeDecoder(),
+            structTypeDecoder,
+            arrayTypeDecoder(),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        private fun arrayTypeDecoder(): ArrayTypeDecoder = { _ ->
+            fail("ArrayTypeDecoder should not be called in this scenario")
+        }
+
+        private fun functionTypeDecoder(): FunctionTypeDecoder = { _ ->
+            fail("FunctionTypeDecoder should not be called in this scenario")
+        }
+
+        private fun structTypeDecoder(): StructTypeDecoder = { _ ->
+            fail("StructTypeDecoder should not be called in this scenario")
+        }
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoderTest.kt
@@ -2,8 +2,8 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.type.function
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -31,7 +31,7 @@ class BinaryFunctionTypeDecoderTest {
         val results = listOf(
             ValueType.Number(NumberType.F64),
             ValueType.Vector(VectorType.V128),
-            ValueType.Reference(ReferenceType.RefNull(HeapType.Func)),
+            ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func)),
         )
 
         val reader = FakeUByteReader {

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/function/BinaryFunctionTypeDecoderTest.kt
@@ -1,6 +1,5 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.function
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
@@ -10,9 +9,8 @@ import io.github.charlietap.chasm.ast.type.ResultType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.ast.type.VectorType
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.result.ResultTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.fixture.ioError
-import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import io.github.charlietap.chasm.decoder.wasm.reader.IOErrorWasmFileReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,10 +32,6 @@ class BinaryFunctionTypeDecoderTest {
             ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func)),
         )
 
-        val reader = FakeUByteReader {
-            Ok(0x60.toUByte())
-        }
-
         val resultSequence = sequenceOf(params, results).iterator()
         val resultDecoder: ResultTypeDecoder = {
             Ok(ResultType(resultSequence.next()))
@@ -47,34 +41,7 @@ class BinaryFunctionTypeDecoderTest {
         val expectedResults = ResultType(results)
         val expected = Ok(FunctionType(expectedParams, expectedResults))
 
-        val actual = BinaryFunctionTypeDecoder(reader, resultDecoder)
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `returns an error when the encoded function type byte doesnt match`() {
-
-        val reader = FakeUByteReader {
-            Ok(0x00.toUByte())
-        }
-
-        val actual = BinaryFunctionTypeDecoder(reader)
-        assertEquals(Err(TypeDecodeError.InvalidFunctionType(0x00.toUByte())), actual)
-    }
-
-    @Test
-    fun `returns an error when the encoded result type is invalid`() {
-
-        val reader = FakeUByteReader {
-            Ok(0x60.toUByte())
-        }
-
-        val expected = Err(TypeDecodeError.InvalidValueType(0x01.toUByte()))
-        val resultTypeDecoder: ResultTypeDecoder = {
-            expected
-        }
-
-        val actual = BinaryFunctionTypeDecoder(reader, resultTypeDecoder)
+        val actual = BinaryFunctionTypeDecoder(FakeWasmBinaryReader(), resultDecoder)
         assertEquals(expected, actual)
     }
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryAbstractHeapTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryAbstractHeapTypeDecoderTest.kt
@@ -1,0 +1,42 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.heap
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BinaryAbstractHeapTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded abstract heap type`() {
+
+        val abstractHeapTypes = mapOf(
+            HEAP_TYPE_ARRAY to AbstractHeapType.Array,
+            HEAP_TYPE_STRUCT to AbstractHeapType.Struct,
+            HEAP_TYPE_I31 to AbstractHeapType.I31,
+            HEAP_TYPE_EQ to AbstractHeapType.Eq,
+            HEAP_TYPE_ANY to AbstractHeapType.Any,
+            HEAP_TYPE_EXTERN to AbstractHeapType.Extern,
+            HEAP_TYPE_FUNC to AbstractHeapType.Func,
+            HEAP_TYPE_NONE to AbstractHeapType.None,
+            HEAP_TYPE_NO_EXTERN to AbstractHeapType.NoExtern,
+            HEAP_TYPE_NO_FUNC to AbstractHeapType.NoFunc,
+        )
+
+        abstractHeapTypes.forEach { (abstractHeapTypeByte, expectedAbstractHeapType) ->
+            val actual = BinaryAbstractHeapTypeDecoder(abstractHeapTypeByte)
+            assertEquals(Ok(expectedAbstractHeapType), actual)
+        }
+    }
+
+    @Test
+    fun `throws an InvalidHeapType error when byte is unrecognised`() {
+
+        val byte: UByte = 0x00u
+
+        val actual = BinaryAbstractHeapTypeDecoder(byte)
+        assertEquals(Err(TypeDecodeError.InvalidHeapType(byte)), actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoderTest.kt
@@ -72,7 +72,7 @@ class BinaryHeapTypeDecoderTest {
                 fakePeekReader = { peekReader },
             )
 
-            val expected = ConcreteHeapType(expectedTypeIndex)
+            val expected = ConcreteHeapType.TypeIndex(expectedTypeIndex)
 
             val actual = BinaryHeapTypeDecoder(reader, abstractHeapTypeDecoder)
             assertEquals(Ok(expected), actual)

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/heap/BinaryHeapTypeDecoderTest.kt
@@ -26,28 +26,20 @@ class BinaryHeapTypeDecoderTest {
 
         abstractHeapTypes.forEach { abstractHeapTypeByte ->
 
-            var timesCalled = 0
             val fakeUByteReader: () -> Result<UByte, WasmDecodeError> = {
-                timesCalled++
                 Ok(abstractHeapTypeByte)
             }
-            val fakeLongReader: () -> Result<Long, WasmDecodeError> = {
-                Ok(117)
-            }
-
             val peekReader = FakeWasmBinaryReader(
                 fakeUByteReader = fakeUByteReader,
             )
 
             val reader = FakeWasmBinaryReader(
                 fakeUByteReader = fakeUByteReader,
-                fakeLongReader = fakeLongReader,
                 fakePeekReader = { peekReader },
             )
 
             val actual = BinaryHeapTypeDecoder(reader, abstractHeapTypeDecoder)
             assertEquals(Ok(AbstractHeapType.Extern), actual)
-            assertEquals(2, timesCalled)
         }
     }
 
@@ -70,22 +62,20 @@ class BinaryHeapTypeDecoderTest {
             }
 
             val expectedTypeIndex = Index.TypeIndex(117u)
-            val fakeLongReader: () -> Result<Long, WasmDecodeError> = {
-                Ok(expectedTypeIndex.idx.toLong())
-            }
 
             val peekReader = FakeWasmBinaryReader(
                 fakeUByteReader = fakeUByteReader,
             )
-
             val reader = FakeWasmBinaryReader(
                 fakeUByteReader = fakeUByteReader,
-                fakeLongReader = fakeLongReader,
+                fakeS33Reader = { Ok(expectedTypeIndex.idx) },
                 fakePeekReader = { peekReader },
             )
 
+            val expected = ConcreteHeapType(expectedTypeIndex)
+
             val actual = BinaryHeapTypeDecoder(reader, abstractHeapTypeDecoder)
-            assertEquals(Ok(ConcreteHeapType(expectedTypeIndex)), actual)
+            assertEquals(Ok(expected), actual)
         }
     }
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinaryRecursiveTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinaryRecursiveTypeDecoderTest.kt
@@ -1,0 +1,82 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.subType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinaryRecursiveTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded recursive type with multiple subtypes`() {
+
+        val prefixByte = MULTIPLE_SUBTYPES_RECURSIVE_TYPE
+
+        val peekReader = FakeUByteReader {
+            Ok(prefixByte)
+        }
+        val reader = FakeWasmBinaryReader(
+            fakePeekReader = { peekReader },
+            fakeUByteReader = { Ok(prefixByte) },
+        )
+
+        val subTypeDecoder: SubTypeDecoder = { _ ->
+            fail("SubTypeDecoder should not be directly called in this scenario")
+        }
+
+        val subTypes: List<SubType> = emptyList()
+        val vectorDecoder: VectorDecoder<SubType> = { _reader, _subdecoder ->
+            assertEquals(reader, _reader)
+            assertEquals(subTypeDecoder, _subdecoder)
+            Ok(Vector(subTypes))
+        }
+
+        val expected = RecursiveType(subTypes)
+
+        val actual = BinaryRecursiveTypeDecoder(
+            reader = reader,
+            subTypeDecoder = subTypeDecoder,
+            vectorDecoder = vectorDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded non prefixed recursive type`() {
+
+        val peekReader = FakeUByteReader {
+            Ok(0x00u)
+        }
+        val reader = FakeWasmBinaryReader(
+            fakePeekReader = { peekReader },
+        )
+
+        val subType = subType()
+        val subTypeDecoder: SubTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(subType)
+        }
+
+        val vectorDecoder: VectorDecoder<SubType> = { _, _ ->
+            fail("VectorDecoder should not be called in this scenario")
+        }
+
+        val expected = RecursiveType(listOf(subType))
+
+        val actual = BinaryRecursiveTypeDecoder(
+            reader = reader,
+            subTypeDecoder = subTypeDecoder,
+            vectorDecoder = vectorDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoderTest.kt
@@ -2,6 +2,7 @@ package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
 
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
 import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.composite.CompositeTypeDecoder
@@ -44,7 +45,8 @@ class BinarySubTypeDecoderTest {
             Ok(compositeType)
         }
 
-        val expected = SubType.Open(typeIndices, compositeType)
+        val expectedHeapTypes = typeIndices.map(ConcreteHeapType::TypeIndex)
+        val expected = SubType.Open(expectedHeapTypes, compositeType)
 
         val actual = BinarySubTypeDecoder(
             reader = reader,
@@ -84,7 +86,8 @@ class BinarySubTypeDecoderTest {
             Ok(compositeType)
         }
 
-        val expected = SubType.Final(typeIndices, compositeType)
+        val expectedHeapTypes = typeIndices.map(ConcreteHeapType::TypeIndex)
+        val expected = SubType.Final(expectedHeapTypes, compositeType)
 
         val actual = BinarySubTypeDecoder(
             reader = reader,

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/recursive/BinarySubTypeDecoderTest.kt
@@ -1,0 +1,134 @@
+package io.github.charlietap.chasm.decoder.wasm.decoder.type.recursive
+
+import com.github.michaelbull.result.Ok
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.decoder.wasm.decoder.section.index.TypeIndexDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.composite.CompositeTypeDecoder
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.Vector
+import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.fixture.type.compositeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class BinarySubTypeDecoderTest {
+
+    @Test
+    fun `can decode an encoded open subtype`() {
+
+        val prefixByte = OPEN_SUB_TYPE
+
+        val peekReader = FakeUByteReader {
+            Ok(prefixByte)
+        }
+        val reader = FakeWasmBinaryReader(
+            fakePeekReader = { peekReader },
+            fakeUByteReader = { Ok(prefixByte) },
+        )
+
+        val typeIndexDecoder = typeIndexDecoder()
+
+        val typeIndices: List<Index.TypeIndex> = emptyList()
+        val vectorDecoder: VectorDecoder<Index.TypeIndex> = { _reader, _subdecoder ->
+            assertEquals(reader, _reader)
+            assertEquals(typeIndexDecoder, _subdecoder)
+            Ok(Vector(typeIndices))
+        }
+
+        val compositeType = compositeType()
+        val compositeTypeDecoder: CompositeTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(compositeType)
+        }
+
+        val expected = SubType.Open(typeIndices, compositeType)
+
+        val actual = BinarySubTypeDecoder(
+            reader = reader,
+            typeIndexDecoder = typeIndexDecoder,
+            vectorDecoder = vectorDecoder,
+            compositeTypeDecoder = compositeTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode an encoded final subtype`() {
+
+        val prefixByte = FINAL_SUB_TYPE
+
+        val peekReader = FakeUByteReader {
+            Ok(prefixByte)
+        }
+        val reader = FakeWasmBinaryReader(
+            fakePeekReader = { peekReader },
+            fakeUByteReader = { Ok(prefixByte) },
+        )
+
+        val typeIndexDecoder = typeIndexDecoder()
+
+        val typeIndices: List<Index.TypeIndex> = emptyList()
+        val vectorDecoder: VectorDecoder<Index.TypeIndex> = { _reader, _subdecoder ->
+            assertEquals(reader, _reader)
+            assertEquals(typeIndexDecoder, _subdecoder)
+            Ok(Vector(typeIndices))
+        }
+
+        val compositeType = compositeType()
+        val compositeTypeDecoder: CompositeTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(compositeType)
+        }
+
+        val expected = SubType.Final(typeIndices, compositeType)
+
+        val actual = BinarySubTypeDecoder(
+            reader = reader,
+            typeIndexDecoder = typeIndexDecoder,
+            vectorDecoder = vectorDecoder,
+            compositeTypeDecoder = compositeTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    @Test
+    fun `can decode a non prefixed encoded subtype`() {
+
+        val peekReader = FakeUByteReader {
+            Ok(0x00u)
+        }
+        val reader = FakeWasmBinaryReader(fakePeekReader = { peekReader })
+
+        val compositeType = compositeType()
+        val compositeTypeDecoder: CompositeTypeDecoder = { _reader ->
+            assertEquals(reader, _reader)
+            Ok(compositeType)
+        }
+
+        val expected = SubType.Final(emptyList(), compositeType)
+
+        val actual = BinarySubTypeDecoder(
+            reader = reader,
+            typeIndexDecoder = typeIndexDecoder(),
+            vectorDecoder = vectorDecoder(),
+            compositeTypeDecoder = compositeTypeDecoder,
+        )
+
+        assertEquals(Ok(expected), actual)
+    }
+
+    companion object {
+        private fun typeIndexDecoder(): TypeIndexDecoder = { _ ->
+            fail("TypeIndexDecoder should not be called in this scenario")
+        }
+
+        private fun vectorDecoder(): VectorDecoder<Index.TypeIndex> = { _, _ ->
+            fail("VectorDecoder should not be called in this scenario")
+        }
+    }
+}

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/reference/BinaryReferenceTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/reference/BinaryReferenceTypeDecoderTest.kt
@@ -1,11 +1,11 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.reference
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.ABSTRACT_HEAP_TYPE_RANGE
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.AbstractHeapTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.heap.HeapTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,22 +16,28 @@ class BinaryReferenceTypeDecoderTest {
     fun `can decode an encoded reference type`() {
 
         val referenceTypeMap = mapOf(
-            REFERENCE_TYPE_FUNC to Ok(ReferenceType.RefNull(HeapType.Func)),
-            REFERENCE_TYPE_EXTERN to Ok(ReferenceType.RefNull(HeapType.Extern)),
-            REFERENCE_TYPE_REF to Ok(ReferenceType.Ref(HeapType.Func)),
-            REFERENCE_TYPE_REF_NULL to Ok(ReferenceType.RefNull(HeapType.Func)),
-            0x11.toUByte() to Err(TypeDecodeError.InvalidReferenceType(0x11.toUByte())),
+            REFERENCE_TYPE_REF to Ok(ReferenceType.Ref(AbstractHeapType.Func)),
+            REFERENCE_TYPE_REF_NULL to Ok(ReferenceType.RefNull(AbstractHeapType.Func)),
         )
+
+        val abstractHeapTypeMap = ABSTRACT_HEAP_TYPE_RANGE.map(UInt::toUByte)
+            .associateWith { Ok(ReferenceType.RefNull(AbstractHeapType.Func)) }
+
+        val referenceAndHeapTypeMap = referenceTypeMap + abstractHeapTypeMap
 
         val reader = FakeWasmBinaryReader()
 
         val heapTypeDecoder: HeapTypeDecoder = { _reader ->
             assertEquals(reader, _reader)
-            Ok(HeapType.Func)
+            Ok(AbstractHeapType.Func)
         }
 
-        referenceTypeMap.forEach { (input, expected) ->
-            val actual = BinaryReferenceTypeDecoder(reader, input, heapTypeDecoder)
+        val abstractHeapTypeDecoder: AbstractHeapTypeDecoder = { _ ->
+            Ok(AbstractHeapType.Func)
+        }
+
+        referenceAndHeapTypeMap.forEach { (input, expected) ->
+            val actual = BinaryReferenceTypeDecoder(reader, input, heapTypeDecoder, abstractHeapTypeDecoder)
             assertEquals(expected, actual)
         }
     }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/table/BinaryTableTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/table/BinaryTableTypeDecoderTest.kt
@@ -1,7 +1,7 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.table
 
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.TableType
@@ -23,7 +23,7 @@ class BinaryTableTypeDecoderTest {
             Ok(expectedByte)
         }
 
-        val refType = ReferenceType.RefNull(HeapType.Func)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Func)
         val referenceTypeDecoder: ReferenceTypeDecoder = { _reader, _opcode ->
             assertEquals(reader, _reader)
             assertEquals(expectedByte, _opcode)

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/value/BinaryValueTypeDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/type/value/BinaryValueTypeDecoderTest.kt
@@ -1,48 +1,103 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.type.value
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.ast.type.VectorType
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.number.NumberTypeDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.type.reference.ReferenceTypeDecoder
-import io.github.charlietap.chasm.decoder.wasm.error.TypeDecodeError
+import io.github.charlietap.chasm.decoder.wasm.decoder.type.vector.VECTOR_TYPE_128
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeUByteReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class BinaryValueTypeDecoderTest {
 
     @Test
-    fun `can decode an encoded value type`() {
+    fun `delegates number type decoding to number type decoder`() {
+        val numberTypes = NUMBER_TYPE_RANGE.map(UInt::toUByte)
 
-        val numberTypeMap = mapOf(
-            0x7F.toUByte() to Ok(ValueType.Number(NumberType.I32)),
-            0x7E.toUByte() to Ok(ValueType.Number(NumberType.I64)),
-            0x7D.toUByte() to Ok(ValueType.Number(NumberType.F32)),
-            0x7C.toUByte() to Ok(ValueType.Number(NumberType.F64)),
-            0x7B.toUByte() to Ok(ValueType.Vector(VectorType.V128)),
-            0x70.toUByte() to Ok(ValueType.Reference(ReferenceType.RefNull(HeapType.Func))),
-            0x6F.toUByte() to Ok(ValueType.Reference(ReferenceType.RefNull(HeapType.Extern))),
-            0x63.toUByte() to Ok(ValueType.Reference(ReferenceType.RefNull(HeapType.Extern))),
-            0x64.toUByte() to Ok(ValueType.Reference(ReferenceType.Ref(HeapType.Extern))),
-            0x00.toUByte() to Err(TypeDecodeError.InvalidValueType(0x00.toUByte())),
-        )
-
-        val referenceTypeDecoder: ReferenceTypeDecoder = { _, _opcode ->
-            if (_opcode == VALUE_TYPE_REFERENCE_REF) {
-                Ok(ReferenceType.Ref(HeapType.Extern))
-            } else {
-                Ok(ReferenceType.RefNull(HeapType.Extern))
-            }
+        val referenceTypeDecoder: ReferenceTypeDecoder = { _, _ ->
+            fail("ReferenceTypeDecoder should not be called in this scenario")
         }
 
-        numberTypeMap.forEach { (input, expected) ->
-            val reader = FakeUByteReader { Ok(input) }
-            val actual = BinaryValueTypeDecoder(reader, referenceTypeDecoder)
-            assertEquals(expected, actual)
+        val expectedNumberType = NumberType.I32
+        val expectedValueType = ValueType.Number(expectedNumberType)
+
+        numberTypes.forEach { numberTypeByte ->
+
+            val numberTypeDecoder: NumberTypeDecoder = { byte ->
+                assertEquals(numberTypeByte, byte)
+
+                Ok(expectedNumberType)
+            }
+
+            val actual = BinaryValueTypeDecoder(
+                reader = FakeUByteReader { Ok(numberTypeByte) },
+                numberTypeDecoder = numberTypeDecoder,
+                referenceTypeDecoder = referenceTypeDecoder,
+            )
+
+            assertEquals(Ok(expectedValueType), actual)
+        }
+    }
+
+    @Test
+    fun `can decode an encoded vector type`() {
+
+        val vectorTypeByte = VECTOR_TYPE_128
+
+        val numberTypeDecoder: NumberTypeDecoder = { _ ->
+            fail("NumberTypeDecoder should not be called in this scenario")
+        }
+
+        val referenceTypeDecoder: ReferenceTypeDecoder = { _, _ ->
+            fail("ReferenceTypeDecoder should not be called in this scenario")
+        }
+
+        val expectedValueType = ValueType.Vector(VectorType.V128)
+
+        val actual = BinaryValueTypeDecoder(
+            reader = FakeUByteReader { Ok(vectorTypeByte) },
+            numberTypeDecoder = numberTypeDecoder,
+            referenceTypeDecoder = referenceTypeDecoder,
+        )
+
+        assertEquals(Ok(expectedValueType), actual)
+    }
+
+    @Test
+    fun `delegates reference type decoding to reference type decoder`() {
+        val referenceTypes = REFERENCE_TYPE_RANGE.map(UInt::toUByte)
+
+        val numberTypeDecoder: NumberTypeDecoder = { _ ->
+            fail("NumberTypeDecoder should not be called in this scenario")
+        }
+
+        val expectedReferenceType = ReferenceType.RefNull(AbstractHeapType.Func)
+        val expectedValueType = ValueType.Reference(expectedReferenceType)
+
+        referenceTypes.forEach { referenceTypeByte ->
+
+            val reader = FakeUByteReader { Ok(referenceTypeByte) }
+
+            val referenceTypeDecoder: ReferenceTypeDecoder = { _reader, _byte ->
+                assertEquals(reader, _reader)
+                assertEquals(referenceTypeByte, _byte)
+
+                Ok(expectedReferenceType)
+            }
+
+            val actual = BinaryValueTypeDecoder(
+                reader = reader,
+                numberTypeDecoder = numberTypeDecoder,
+                referenceTypeDecoder = referenceTypeDecoder,
+            )
+
+            assertEquals(Ok(expectedValueType), actual)
         }
     }
 }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ElementModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ElementModuleTest.kt
@@ -13,10 +13,13 @@ import io.github.charlietap.chasm.ast.module.Table
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.Limits
+import io.github.charlietap.chasm.ast.type.RecursiveType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.ast.type.TableType
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeSourceReader
@@ -36,7 +39,12 @@ class ElementModuleTest {
             params = ResultType(emptyList()),
             results = ResultType(emptyList()),
         )
-        val expectedType = Type(Index.TypeIndex(0u), expectedFunctionType)
+        val expectedRecursiveType = RecursiveType(
+            listOf(
+                SubType.Final(emptyList(), CompositeType.Function(expectedFunctionType)),
+            ),
+        )
+        val expectedType = Type(Index.TypeIndex(0u), expectedRecursiveType)
 
         val expectedFunction = Function(
             idx = Index.FunctionIndex(0u),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ElementModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ElementModuleTest.kt
@@ -12,8 +12,8 @@ import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Table
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -47,13 +47,13 @@ class ElementModuleTest {
 
         val table = Table(
             idx = Index.TableIndex(0u),
-            type = TableType(ReferenceType.RefNull(HeapType.Func), Limits(1u)),
-            initExpression = Expression(listOf(ReferenceInstruction.RefNull(HeapType.Func))),
+            type = TableType(ReferenceType.RefNull(AbstractHeapType.Func), Limits(1u)),
+            initExpression = Expression(listOf(ReferenceInstruction.RefNull(AbstractHeapType.Func))),
         )
 
         val elementSegment = ElementSegment(
             idx = Index.ElementIndex(0u),
-            type = ReferenceType.RefNull(HeapType.Func),
+            type = ReferenceType.RefNull(AbstractHeapType.Func),
             initExpressions = listOf(Expression(ReferenceInstruction.RefFunc(Index.FunctionIndex(0u)))),
             mode = ElementSegment.Mode.Active(
                 tableIndex = Index.TableIndex(0u),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
@@ -14,9 +14,9 @@ import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Table
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
 import io.github.charlietap.chasm.ast.type.NumberType
@@ -57,11 +57,11 @@ class ExportModuleTest {
             descriptor = Export.Descriptor.Function(Index.FunctionIndex(0u)),
         )
 
-        val expectedTableType = TableType(ReferenceType.RefNull(HeapType.Func), Limits(1u))
+        val expectedTableType = TableType(ReferenceType.RefNull(AbstractHeapType.Func), Limits(1u))
         val expectedTable = Table(
             idx = Index.TableIndex(0u),
             type = expectedTableType,
-            initExpression = Expression(listOf(ReferenceInstruction.RefNull(HeapType.Func))),
+            initExpression = Expression(listOf(ReferenceInstruction.RefNull(AbstractHeapType.Func))),
         )
 
         val expectedTableExport = Export(

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
@@ -15,14 +15,17 @@ import io.github.charlietap.chasm.ast.module.Table
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
 import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.NumberType
+import io.github.charlietap.chasm.ast.type.RecursiveType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.ast.type.TableType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.ast.value.NameValue
@@ -44,7 +47,13 @@ class ExportModuleTest {
             params = ResultType(emptyList()),
             results = ResultType(emptyList()),
         )
-        val expectedFunctionExportType = Type(Index.TypeIndex(0u), expectedFunctionType)
+        val expectedRecursiveType = RecursiveType(
+            listOf(
+                SubType.Final(emptyList(), CompositeType.Function(expectedFunctionType)),
+            ),
+        )
+
+        val expectedFunctionExportType = Type(Index.TypeIndex(0u), expectedRecursiveType)
 
         val expectedFunction = Function(
             idx = Index.FunctionIndex(0u),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ExportModuleTest.kt
@@ -19,6 +19,7 @@ import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
+import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -82,7 +83,7 @@ class ExportModuleTest {
 
         val expectedGlobalType = GlobalType(
             ValueType.Number(NumberType.I32),
-            GlobalType.Mutability.Var,
+            Mutability.Var,
         )
 
         val expectedGlobal = Global(

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/FunctionModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/FunctionModuleTest.kt
@@ -10,12 +10,15 @@ import io.github.charlietap.chasm.ast.module.Local
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeSourceReader
+import io.github.charlietap.chasm.fixture.type.recursiveType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -42,7 +45,15 @@ class FunctionModuleTest {
                 ),
             ),
         )
-        val expectedType = Type(Index.TypeIndex(0u), expectedFunctionType)
+        val expectedRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedFunctionType),
+                ),
+            ),
+        )
+        val expectedType = Type(Index.TypeIndex(0u), expectedRecursiveType)
 
         val expectedFunction = Function(
             idx = Index.FunctionIndex(0u),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/GlobalModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/GlobalModuleTest.kt
@@ -9,6 +9,7 @@ import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.ast.type.GlobalType
+import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
@@ -29,7 +30,7 @@ class GlobalModuleTest {
             idx = Index.GlobalIndex(0u),
             type = GlobalType(
                 valueType = ValueType.Number(NumberType.I32),
-                GlobalType.Mutability.Const,
+                Mutability.Const,
             ),
             initExpression = Expression(
                 listOf(NumericInstruction.I32Const(10)),
@@ -40,7 +41,7 @@ class GlobalModuleTest {
             idx = Index.GlobalIndex(1u),
             type = GlobalType(
                 valueType = ValueType.Number(NumberType.I32),
-                GlobalType.Mutability.Var,
+                Mutability.Var,
             ),
             initExpression = Expression(
                 listOf(NumericInstruction.I32Const(20)),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
@@ -8,6 +8,7 @@ import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.Limits
@@ -16,11 +17,13 @@ import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.ast.type.TableType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.ast.value.NameValue
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeSourceReader
+import io.github.charlietap.chasm.fixture.type.recursiveType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -37,7 +40,15 @@ class ImportModuleTest {
             params = ResultType(emptyList()),
             results = ResultType(listOf(ValueType.Number(NumberType.I32))),
         )
-        val expectedFunctionImportType = Type(Index.TypeIndex(0u), expectedFunctionType)
+        val expectedRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedFunctionType),
+                ),
+            ),
+        )
+        val expectedFunctionImportType = Type(Index.TypeIndex(0u), expectedRecursiveType)
 
         val expectedFunctionImport = Import(
             moduleName = NameValue("env"),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
@@ -7,9 +7,9 @@ import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
 import io.github.charlietap.chasm.ast.type.NumberType
@@ -44,7 +44,7 @@ class ImportModuleTest {
             descriptor = Import.Descriptor.Function(Index.TypeIndex(0u)),
         )
 
-        val expectedTableType = TableType(ReferenceType.RefNull(HeapType.Func), Limits(1u, 2u))
+        val expectedTableType = TableType(ReferenceType.RefNull(AbstractHeapType.Func), Limits(1u, 2u))
 
         val expectedTableImport = Import(
             moduleName = NameValue("env"),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/ImportModuleTest.kt
@@ -12,6 +12,7 @@ import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.MemoryType
+import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -62,7 +63,7 @@ class ImportModuleTest {
 
         val expectedGlobalType = GlobalType(
             ValueType.Number(NumberType.I32),
-            GlobalType.Mutability.Const,
+            Mutability.Const,
         )
 
         val expectedGlobalImport = Import(

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/StartModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/StartModuleTest.kt
@@ -9,10 +9,13 @@ import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.StartFunction
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeSourceReader
+import io.github.charlietap.chasm.fixture.type.recursiveType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -29,7 +32,15 @@ class StartModuleTest {
             params = ResultType(emptyList()),
             results = ResultType(emptyList()),
         )
-        val expectedType = Type(Index.TypeIndex(0u), expectedFunctionType)
+        val expectedRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedFunctionType),
+                ),
+            ),
+        )
+        val expectedType = Type(Index.TypeIndex(0u), expectedRecursiveType)
 
         val expectedFunction = Function(
             idx = Index.FunctionIndex(0u),

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TableModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TableModuleTest.kt
@@ -8,7 +8,7 @@ import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Table
 import io.github.charlietap.chasm.ast.module.Version
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.TableType
@@ -29,10 +29,10 @@ class TableModuleTest {
         val expectedTable = Table(
             idx = Index.TableIndex(0u),
             type = TableType(
-                referenceType = ReferenceType.RefNull(HeapType.Func),
+                referenceType = ReferenceType.RefNull(AbstractHeapType.Func),
                 limits = Limits(1u, 2u),
             ),
-            initExpression = Expression(listOf(ReferenceInstruction.RefNull(HeapType.Func))),
+            initExpression = Expression(listOf(ReferenceInstruction.RefNull(AbstractHeapType.Func))),
         )
 
         val expected = Ok(

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TypeModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TypeModuleTest.kt
@@ -7,14 +7,17 @@ import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.ast.type.CompositeType
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.SubType
 import io.github.charlietap.chasm.ast.type.ValueType
 import io.github.charlietap.chasm.ast.type.VectorType
 import io.github.charlietap.chasm.decoder.wasm.WasmModuleDecoder
 import io.github.charlietap.chasm.decoder.wasm.reader.FakeSourceReader
+import io.github.charlietap.chasm.fixture.type.recursiveType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -38,7 +41,15 @@ class TypeModuleTest {
             ),
             results = ResultType(listOf(ValueType.Number(NumberType.I32))),
         )
-        val expectedNumberType = Type(Index.TypeIndex(0u), expectedNumberTypeFunctionType)
+        val expectedNumberTypeRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedNumberTypeFunctionType),
+                ),
+            ),
+        )
+        val expectedNumberType = Type(Index.TypeIndex(0u), expectedNumberTypeRecursiveType)
 
         val expectedVectorTypeFunctionType = FunctionType(
             params = ResultType(
@@ -48,7 +59,15 @@ class TypeModuleTest {
             ),
             results = ResultType(listOf(ValueType.Vector(VectorType.V128))),
         )
-        val expectedVectorType = Type(Index.TypeIndex(1u), expectedVectorTypeFunctionType)
+        val expectedVectorTypeRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedVectorTypeFunctionType),
+                ),
+            ),
+        )
+        val expectedVectorType = Type(Index.TypeIndex(1u), expectedVectorTypeRecursiveType)
 
         val expectedReferenceTypeFunctionType = FunctionType(
             params = ResultType(
@@ -59,7 +78,15 @@ class TypeModuleTest {
             ),
             results = ResultType(listOf(ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func)))),
         )
-        val expectedReferenceType = Type(Index.TypeIndex(2u), expectedReferenceTypeFunctionType)
+        val expectedReferenceTypeRecursiveType = recursiveType(
+            subTypes = listOf(
+                SubType.Final(
+                    superTypes = emptyList(),
+                    compositeType = CompositeType.Function(expectedReferenceTypeFunctionType),
+                ),
+            ),
+        )
+        val expectedReferenceType = Type(Index.TypeIndex(2u), expectedReferenceTypeRecursiveType)
 
         val expected = Ok(
             Module(

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TypeModuleTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/integration/TypeModuleTest.kt
@@ -6,8 +6,8 @@ import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.ast.module.Version
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.FunctionType
-import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -53,11 +53,11 @@ class TypeModuleTest {
         val expectedReferenceTypeFunctionType = FunctionType(
             params = ResultType(
                 listOf(
-                    ValueType.Reference(ReferenceType.RefNull(HeapType.Func)),
-                    ValueType.Reference(ReferenceType.RefNull(HeapType.Extern)),
+                    ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func)),
+                    ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Extern)),
                 ),
             ),
-            results = ResultType(listOf(ValueType.Reference(ReferenceType.RefNull(HeapType.Func)))),
+            results = ResultType(listOf(ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func)))),
         )
         val expectedReferenceType = Type(Index.TypeIndex(2u), expectedReferenceTypeFunctionType)
 

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/FakeWasmBinaryReader.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/FakeWasmBinaryReader.kt
@@ -11,6 +11,7 @@ internal fun FakeWasmBinaryReader(
     fakeUBytesReader: ((UInt) -> Result<UByteArray, WasmDecodeError>)? = null,
     fakeIntReader: (() -> Result<Int, WasmDecodeError>)? = null,
     fakeUIntReader: (() -> Result<UInt, WasmDecodeError>)? = null,
+    fakeS33Reader: (() -> Result<UInt, WasmDecodeError>)? = null,
     fakeLongReader: (() -> Result<Long, WasmDecodeError>)? = null,
     fakeFloatReader: (() -> Result<Float, WasmDecodeError>)? = null,
     fakeDoubleReader: (() -> Result<Double, WasmDecodeError>)? = null,
@@ -40,6 +41,8 @@ internal fun FakeWasmBinaryReader(
 
     override fun uint(): Result<UInt, WasmDecodeError> = (fakeUIntReader ?: fail)()
 
+    override fun s33(): Result<UInt, WasmDecodeError> = (fakeS33Reader ?: fail)()
+
     override fun long(): Result<Long, WasmDecodeError> = (fakeLongReader ?: fail)()
 
     override fun float(): Result<Float, WasmDecodeError> = (fakeFloatReader ?: fail)()
@@ -68,6 +71,10 @@ internal fun FakeIntReader(
 internal fun FakeUIntReader(
     uint: () -> Result<UInt, WasmDecodeError>,
 ): WasmBinaryReader = FakeWasmBinaryReader(fakeUIntReader = uint)
+
+internal fun FakeS33Reader(
+    s33: () -> Result<UInt, WasmDecodeError>,
+): WasmBinaryReader = FakeWasmBinaryReader(fakeS33Reader = s33)
 
 internal fun FakeLongReader(
     long: () -> Result<Long, WasmDecodeError>,

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/IOErrorWasmBinaryReader.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/IOErrorWasmBinaryReader.kt
@@ -18,6 +18,8 @@ internal fun IOErrorWasmFileReader(err: Err<WasmDecodeError.IOError>): WasmBinar
 
     override fun uint(): Result<UInt, WasmDecodeError> = err
 
+    override fun s33(): Result<UInt, WasmDecodeError> = err
+
     override fun long(): Result<Long, WasmDecodeError> = err
 
     override fun float(): Result<Float, WasmDecodeError> = err

--- a/executor/instantiator/build.gradle.kts
+++ b/executor/instantiator/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
                 api(projects.executor.runtime)
                 api(projects.executor.runtimeExt)
                 api(projects.executor.invoker)
+                api(projects.executor.type)
                 api(libs.result)
 
                 implementation(projects.executor.memory)

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/ModuleInstantiatorImpl.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/ModuleInstantiatorImpl.kt
@@ -8,13 +8,10 @@ import io.github.charlietap.chasm.executor.instantiator.allocation.ModuleAllocat
 import io.github.charlietap.chasm.executor.instantiator.allocation.ModuleAllocatorImpl
 import io.github.charlietap.chasm.executor.instantiator.allocation.PartialModuleAllocator
 import io.github.charlietap.chasm.executor.instantiator.allocation.PartialModuleAllocatorImpl
-import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifier
-import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifierImpl
 import io.github.charlietap.chasm.executor.instantiator.initialization.MemoryInitializer
 import io.github.charlietap.chasm.executor.instantiator.initialization.MemoryInitializerImpl
 import io.github.charlietap.chasm.executor.instantiator.initialization.TableInitializer
 import io.github.charlietap.chasm.executor.instantiator.initialization.TableInitializerImpl
-import io.github.charlietap.chasm.executor.instantiator.validation.ImportValidator
 import io.github.charlietap.chasm.executor.invoker.ExpressionEvaluator
 import io.github.charlietap.chasm.executor.invoker.ExpressionEvaluatorImpl
 import io.github.charlietap.chasm.executor.invoker.FunctionInvoker
@@ -36,10 +33,8 @@ fun ModuleInstantiatorImpl(
         store = store,
         module = module,
         imports = imports,
-        classifier = ::ExternalValueClassifierImpl,
         pallocator = ::PartialModuleAllocatorImpl,
         allocator = ::ModuleAllocatorImpl,
-        validator = ::ImportValidator,
         invoker = ::FunctionInvokerImpl,
         evaluator = ::ExpressionEvaluatorImpl,
         tableInitializer = ::TableInitializerImpl,
@@ -50,10 +45,8 @@ internal fun ModuleInstantiatorImpl(
     store: Store,
     module: Module,
     imports: List<ExternalValue>,
-    classifier: ExternalValueClassifier,
     pallocator: PartialModuleAllocator,
     allocator: ModuleAllocator,
-    validator: ImportValidator,
     invoker: FunctionInvoker,
     evaluator: ExpressionEvaluator,
     tableInitializer: TableInitializer,
@@ -63,17 +56,6 @@ internal fun ModuleInstantiatorImpl(
 
     if (module.imports.size != imports.size) {
         Err(InstantiationError.MissingImport).bind<ModuleInstance>()
-    }
-
-    val classifiedImports = imports.map { import ->
-        classifier(store, import).bind()
-    }
-
-    // it's an invariant that external values are ordered and matched
-    // before the ModuleInstantiator is called
-    module.imports.forEachIndexed { idx, import ->
-        val classified = classifiedImports[idx]
-        validator(module, import, classified).bind()
     }
 
     val partialInstance = pallocator(store, module, imports).bind()

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/PartialModuleAllocatorImpl.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/PartialModuleAllocatorImpl.kt
@@ -2,10 +2,17 @@ package io.github.charlietap.chasm.executor.instantiator.allocation
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
 import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.ast.module.Type
 import io.github.charlietap.chasm.executor.instantiator.allocation.function.WasmFunctionAllocator
 import io.github.charlietap.chasm.executor.instantiator.allocation.function.WasmFunctionAllocatorImpl
+import io.github.charlietap.chasm.executor.instantiator.allocation.type.TypeAllocator
+import io.github.charlietap.chasm.executor.instantiator.allocation.type.TypeAllocatorImpl
+import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifier
+import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifierImpl
+import io.github.charlietap.chasm.executor.instantiator.validation.ImportValidator
+import io.github.charlietap.chasm.executor.instantiator.validation.ImportValidatorImpl
 import io.github.charlietap.chasm.executor.runtime.error.InstantiationError
 import io.github.charlietap.chasm.executor.runtime.ext.addFunctionAddress
 import io.github.charlietap.chasm.executor.runtime.ext.addGlobalAddress
@@ -23,6 +30,9 @@ internal fun PartialModuleAllocatorImpl(
         module = module,
         imports = imports,
         wasmFunctionAllocator = ::WasmFunctionAllocatorImpl,
+        typeAllocator = ::TypeAllocatorImpl,
+        classifier = ::ExternalValueClassifierImpl,
+        importValidator = ::ImportValidatorImpl,
     )
 
 internal fun PartialModuleAllocatorImpl(
@@ -30,9 +40,25 @@ internal fun PartialModuleAllocatorImpl(
     module: Module,
     imports: List<ExternalValue>,
     wasmFunctionAllocator: WasmFunctionAllocator,
+    typeAllocator: TypeAllocator,
+    classifier: ExternalValueClassifier,
+    importValidator: ImportValidator,
 ): Result<ModuleInstance, InstantiationError> = binding {
 
-    val instance = ModuleInstance(module.types.map(Type::functionType))
+    val instance = ModuleInstance(typeAllocator(module.types.map(Type::recursiveType)))
+
+    val classifiedImports = imports.map { import ->
+        classifier(store, import).mapError {
+            InstantiationError.ClassificationError
+        }.bind()
+    }
+
+    // it's an invariant that external values are ordered and matched
+    // before the ModuleInstantiator is called
+    module.imports.forEachIndexed { idx, import ->
+        val classified = classifiedImports[idx]
+        importValidator(instance, import, classified).bind()
+    }
 
     imports.forEach { import ->
         when (import) {

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/function/HostFunctionAllocatorImpl.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/function/HostFunctionAllocatorImpl.kt
@@ -5,13 +5,15 @@ import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.store.Store
+import io.github.charlietap.chasm.executor.type.ext.definedType
 
 fun HostFunctionAllocatorImpl(
     store: Store,
-    type: FunctionType,
+    functionType: FunctionType,
     function: HostFunction,
 ): Address.Function {
 
+    val type = functionType.definedType()
     val instance = FunctionInstance.HostFunction(type, function)
 
     store.functions.add(instance)

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/type/TypeAllocator.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/type/TypeAllocator.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.executor.instantiator.allocation.type
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+typealias TypeAllocator = (List<RecursiveType>) -> List<DefinedType>

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/type/TypeAllocatorImpl.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/allocation/type/TypeAllocatorImpl.kt
@@ -1,0 +1,40 @@
+package io.github.charlietap.chasm.executor.instantiator.allocation.type
+
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRoller
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRollerImpl
+import io.github.charlietap.chasm.executor.type.rolling.substitution.ConcreteHeapTypeSubstitutor
+import io.github.charlietap.chasm.executor.type.rolling.substitution.DefinedTypeSubstitutorImpl
+import io.github.charlietap.chasm.executor.type.rolling.substitution.TypeSubstitutor
+
+fun TypeAllocatorImpl(
+    recursiveTypes: List<RecursiveType>,
+): List<DefinedType> =
+    TypeAllocatorImpl(
+        recursiveTypes = recursiveTypes,
+        definedTypeRoller = ::DefinedTypeRollerImpl,
+        definedTypeSubstitutor = ::DefinedTypeSubstitutorImpl,
+    )
+
+fun TypeAllocatorImpl(
+    recursiveTypes: List<RecursiveType>,
+    definedTypeRoller: DefinedTypeRoller,
+    definedTypeSubstitutor: TypeSubstitutor<DefinedType>,
+): List<DefinedType> = recursiveTypes.fold(emptyList()) { acc, recursiveType ->
+    val size = acc.size
+
+    val substitutor: ConcreteHeapTypeSubstitutor = { heapType ->
+        when (heapType) {
+            is ConcreteHeapType.TypeIndex -> {
+                ConcreteHeapType.Defined(acc[size - 1])
+            }
+            else -> heapType
+        }
+    }
+
+    acc + definedTypeRoller(size, recursiveType).map { definedType ->
+        definedTypeSubstitutor(definedType, substitutor)
+    }
+}

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/validation/ImportValidator.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/validation/ImportValidator.kt
@@ -2,8 +2,8 @@ package io.github.charlietap.chasm.executor.instantiator.validation
 
 import com.github.michaelbull.result.Result
 import io.github.charlietap.chasm.ast.module.Import
-import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.executor.instantiator.classification.ClassifiedExternalValue
 import io.github.charlietap.chasm.executor.runtime.error.InstantiationError
+import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 
-internal typealias ImportValidator = (Module, Import, ClassifiedExternalValue) -> Result<Unit, InstantiationError.UnexpectedImport>
+internal typealias ImportValidator = (ModuleInstance, Import, ClassifiedExternalValue) -> Result<Unit, InstantiationError.UnexpectedImport>

--- a/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/validation/ImportValidatorImpl.kt
+++ b/executor/instantiator/src/commonMain/kotlin/io/github/charlietap/chasm/executor/instantiator/validation/ImportValidatorImpl.kt
@@ -5,22 +5,22 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Import
-import io.github.charlietap.chasm.ast.module.Module
 import io.github.charlietap.chasm.executor.instantiator.classification.ClassifiedExternalValue
 import io.github.charlietap.chasm.executor.runtime.error.InstantiationError
+import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.executor.runtime.type.ExternalType
 
-internal fun ImportValidator(
-    module: Module,
+internal fun ImportValidatorImpl(
+    instance: ModuleInstance,
     import: Import,
     classified: ClassifiedExternalValue,
 ): Result<Unit, InstantiationError.UnexpectedImport> = binding {
     val matches = when (val descriptor = import.descriptor) {
         is Import.Descriptor.Function -> {
-            val type = module.types[descriptor.typeIndex.idx.toInt()].functionType
+            val type = instance.types[descriptor.typeIndex.idx.toInt()]
 
             val externType = when (classified.type) {
-                is ExternalType.Function -> Ok(classified.type.functionType)
+                is ExternalType.Function -> Ok(classified.type.definedType)
                 else -> Err(InstantiationError.UnexpectedImport(import.moduleName.name, import.entityName.name))
             }.bind()
 

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/ModuleInstantiatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/ModuleInstantiatorImplTest.kt
@@ -5,17 +5,13 @@ import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.executor.instantiator.allocation.ModuleAllocator
 import io.github.charlietap.chasm.executor.instantiator.allocation.PartialModuleAllocator
-import io.github.charlietap.chasm.executor.instantiator.classification.ClassifiedExternalValue
-import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifier
 import io.github.charlietap.chasm.executor.instantiator.initialization.MemoryInitializer
 import io.github.charlietap.chasm.executor.instantiator.initialization.TableInitializer
-import io.github.charlietap.chasm.executor.instantiator.validation.ImportValidator
 import io.github.charlietap.chasm.executor.invoker.ExpressionEvaluator
 import io.github.charlietap.chasm.executor.invoker.FunctionInvoker
 import io.github.charlietap.chasm.executor.runtime.Arity
 import io.github.charlietap.chasm.executor.runtime.instance.ExternalValue
 import io.github.charlietap.chasm.executor.runtime.store.Address
-import io.github.charlietap.chasm.executor.runtime.type.ExternalType
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.module.elementSegment
@@ -26,7 +22,6 @@ import io.github.charlietap.chasm.fixture.module.module
 import io.github.charlietap.chasm.fixture.module.startFunction
 import io.github.charlietap.chasm.fixture.module.table
 import io.github.charlietap.chasm.fixture.store
-import io.github.charlietap.chasm.fixture.type.functionType
 import io.github.charlietap.chasm.fixture.type.heapType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,24 +50,6 @@ class ModuleInstantiatorImplTest {
             startFunction = startFunction,
         )
         val imports = listOf(ExternalValue.Function(Address.Function(0)))
-        val classified = ClassifiedExternalValue(
-            type = ExternalType.Function(functionType()),
-            value = imports[0],
-        )
-        val classifier: ExternalValueClassifier = { eStore, eExtern ->
-            assertEquals(store, eStore)
-            assertEquals(imports[0], eExtern)
-
-            Ok(classified)
-        }
-
-        val validator: ImportValidator = { iModule, iImport, iClassifiedExtern ->
-            assertEquals(module, iModule)
-            assertEquals(import, iImport)
-            assertEquals(classified, iClassifiedExtern)
-
-            Ok(Unit)
-        }
 
         val partialInstance = moduleInstance(
             functionAddresses = mutableListOf(Address.Function(0)),
@@ -137,10 +114,8 @@ class ModuleInstantiatorImplTest {
             store = store,
             module = module,
             imports = imports,
-            classifier = classifier,
             pallocator = pallocator,
             allocator = allocator,
-            validator = validator,
             invoker = invoker,
             evaluator = evaluator,
             tableInitializer = tableInitializer,

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/ModuleAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/ModuleAllocatorImplTest.kt
@@ -2,7 +2,7 @@ package io.github.charlietap.chasm.executor.instantiator.runtime.allocation
 
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.value.NameValue
 import io.github.charlietap.chasm.executor.instantiator.allocation.ModuleAllocatorImpl
@@ -58,9 +58,9 @@ class ModuleAllocatorImplTest {
         val globalInitValues = listOf(globalInitValue)
         val tableInitValue = ReferenceValue.Null(heapType())
         val tableInitValues = listOf(tableInitValue)
-        val refType = ReferenceType.RefNull(HeapType.Extern)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Extern)
         val elementSegment = elementSegment(type = refType)
-        val refVals = listOf(ReferenceValue.Null(HeapType.Extern))
+        val refVals = listOf(ReferenceValue.Null(AbstractHeapType.Extern))
         val elementSegmentReferences = listOf(refVals)
         val bytes = ubyteArrayOf()
         val dataSegment = dataSegment(initData = bytes)

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/ModuleAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/ModuleAllocatorImplTest.kt
@@ -17,6 +17,8 @@ import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
+import io.github.charlietap.chasm.executor.type.ext.definedType
+import io.github.charlietap.chasm.executor.type.ext.recursiveType
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.module.dataSegment
 import io.github.charlietap.chasm.fixture.module.elementSegment
@@ -49,8 +51,9 @@ class ModuleAllocatorImplTest {
             function(typeIndex = typeIndex)
         val type = type(
             idx = typeIndex,
-            functionType = functionType,
+            recursiveType = functionType.recursiveType(),
         )
+        val definedType = functionType.definedType()
         val table = table()
         val memory = memory()
         val global = global()
@@ -164,13 +167,13 @@ class ModuleAllocatorImplTest {
         }
 
         val partial = moduleInstance(
-            types = listOf(type.functionType),
+            types = listOf(definedType),
             functionAddresses = mutableListOf(importFunctionAddress, functionAddress),
             globalAddresses = mutableListOf(importGlobalAddress),
         )
 
         val expected = ModuleInstance(
-            types = listOf(type.functionType),
+            types = listOf(definedType),
             functionAddresses = mutableListOf(importFunctionAddress, functionAddress),
             tableAddresses = mutableListOf(importTableAddress, tableAddress),
             memAddresses = mutableListOf(importMemoryAddress, memoryAddress),

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/PartialModuleAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/PartialModuleAllocatorImplTest.kt
@@ -2,7 +2,7 @@ package io.github.charlietap.chasm.executor.instantiator.runtime.allocation
 
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.value.NameValue
 import io.github.charlietap.chasm.executor.instantiator.allocation.PartialModuleAllocatorImpl
@@ -45,7 +45,7 @@ class PartialModuleAllocatorImplTest {
         val table = table()
         val memory = memory()
         val global = global()
-        val refType = ReferenceType.RefNull(HeapType.Extern)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Extern)
         val elementSegment = elementSegment(type = refType)
         val bytes = ubyteArrayOf()
         val dataSegment = dataSegment(initData = bytes)

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/PartialModuleAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/PartialModuleAllocatorImplTest.kt
@@ -4,26 +4,37 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
-import io.github.charlietap.chasm.ast.value.NameValue
 import io.github.charlietap.chasm.executor.instantiator.allocation.PartialModuleAllocatorImpl
 import io.github.charlietap.chasm.executor.instantiator.allocation.function.WasmFunctionAllocatorImpl
+import io.github.charlietap.chasm.executor.instantiator.allocation.type.TypeAllocatorImpl
+import io.github.charlietap.chasm.executor.instantiator.classification.ClassifiedExternalValue
+import io.github.charlietap.chasm.executor.instantiator.classification.ExternalValueClassifier
+import io.github.charlietap.chasm.executor.instantiator.validation.ImportValidator
 import io.github.charlietap.chasm.executor.runtime.instance.ExternalValue
 import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
+import io.github.charlietap.chasm.executor.type.ext.definedType
+import io.github.charlietap.chasm.fixture.instance.externalValue
+import io.github.charlietap.chasm.fixture.instance.functionAddress
+import io.github.charlietap.chasm.fixture.instance.globalAddress
+import io.github.charlietap.chasm.fixture.instance.memoryAddress
+import io.github.charlietap.chasm.fixture.instance.tableAddress
 import io.github.charlietap.chasm.fixture.module.dataSegment
 import io.github.charlietap.chasm.fixture.module.elementSegment
-import io.github.charlietap.chasm.fixture.module.export
 import io.github.charlietap.chasm.fixture.module.function
-import io.github.charlietap.chasm.fixture.module.functionExportDescriptor
+import io.github.charlietap.chasm.fixture.module.functionImportDescriptor
 import io.github.charlietap.chasm.fixture.module.global
-import io.github.charlietap.chasm.fixture.module.globalExportDescriptor
+import io.github.charlietap.chasm.fixture.module.globalImportDescriptor
+import io.github.charlietap.chasm.fixture.module.import
 import io.github.charlietap.chasm.fixture.module.memory
-import io.github.charlietap.chasm.fixture.module.memoryExportDescriptor
+import io.github.charlietap.chasm.fixture.module.memoryImportDescriptor
 import io.github.charlietap.chasm.fixture.module.module
 import io.github.charlietap.chasm.fixture.module.table
-import io.github.charlietap.chasm.fixture.module.tableExportDescriptor
+import io.github.charlietap.chasm.fixture.module.tableImportDescriptor
 import io.github.charlietap.chasm.fixture.module.type
 import io.github.charlietap.chasm.fixture.store
+import io.github.charlietap.chasm.fixture.type.externalType
+import io.github.charlietap.chasm.fixture.type.functionRecursiveType
 import io.github.charlietap.chasm.fixture.type.functionType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,13 +45,14 @@ class PartialModuleAllocatorImplTest {
     fun `can allocate a partial module instance`() {
 
         val store = store()
-        val functionType = functionType()
         val typeIndex = Index.TypeIndex(0u)
         val functionAddress = Address.Function(0)
         val function = function(typeIndex = typeIndex)
+        val functionType = functionType()
+        val recursiveType = functionRecursiveType(functionType)
         val type = type(
             idx = typeIndex,
-            functionType = functionType,
+            recursiveType = recursiveType,
         )
         val table = table()
         val memory = memory()
@@ -50,38 +62,20 @@ class PartialModuleAllocatorImplTest {
         val bytes = ubyteArrayOf()
         val dataSegment = dataSegment(initData = bytes)
 
-        val importFunctionAddress = Address.Function(1)
-        val importTableAddress = Address.Table(1)
-        val importMemoryAddress = Address.Memory(1)
-        val importGlobalAddress = Address.Global(1)
+        val moduleFunctionImport = import(descriptor = functionImportDescriptor())
+        val moduleTableImport = import(descriptor = tableImportDescriptor())
+        val moduleMemoryImport = import(descriptor = memoryImportDescriptor())
+        val moduleGlobalImport = import(descriptor = globalImportDescriptor())
+
+        val importFunctionAddress = functionAddress()
+        val importTableAddress = tableAddress()
+        val importMemoryAddress = memoryAddress()
+        val importGlobalAddress = globalAddress()
         val imports = listOf(
             ExternalValue.Function(importFunctionAddress),
             ExternalValue.Table(importTableAddress),
             ExternalValue.Memory(importMemoryAddress),
             ExternalValue.Global(importGlobalAddress),
-        )
-
-        val functionExport = export(
-            name = NameValue("function_export"),
-            descriptor = functionExportDescriptor(),
-        )
-        val tableExport = export(
-            name = NameValue("table_export"),
-            descriptor = tableExportDescriptor(),
-        )
-        val memoryExport = export(
-            name = NameValue("memory_export"),
-            descriptor = memoryExportDescriptor(),
-        )
-        val globalExport = export(
-            name = NameValue("global_export"),
-            descriptor = globalExportDescriptor(),
-        )
-        val exports = listOf(
-            functionExport,
-            tableExport,
-            memoryExport,
-            globalExport,
         )
 
         val module = module(
@@ -92,11 +86,27 @@ class PartialModuleAllocatorImplTest {
             globals = listOf(global),
             elementSegments = listOf(elementSegment),
             dataSegments = listOf(dataSegment),
-            exports = exports,
+            imports = listOf(moduleFunctionImport, moduleTableImport, moduleMemoryImport, moduleGlobalImport),
+            exports = emptyList(),
         )
 
+        val importIter = imports.iterator()
+        val classifiedExternalValue = ClassifiedExternalValue(externalType(), externalValue())
+        val classifier: ExternalValueClassifier = { _store, _externalValue ->
+            assertEquals(store, _store)
+            assertEquals(importIter.next(), _externalValue)
+            Ok(classifiedExternalValue)
+        }
+
+        val validatorIter = module.imports.iterator()
+        val validator: ImportValidator = { _, _import, _classified ->
+            assertEquals(validatorIter.next(), _import)
+            assertEquals(classifiedExternalValue, _classified)
+            Ok(Unit)
+        }
+
         val expected = ModuleInstance(
-            types = listOf(type.functionType),
+            types = listOf(type.recursiveType.definedType()),
             functionAddresses = mutableListOf(importFunctionAddress, functionAddress),
             tableAddresses = mutableListOf(),
             memAddresses = mutableListOf(),
@@ -111,6 +121,9 @@ class PartialModuleAllocatorImplTest {
             module = module,
             imports = imports,
             wasmFunctionAllocator = ::WasmFunctionAllocatorImpl,
+            typeAllocator = ::TypeAllocatorImpl,
+            classifier = classifier,
+            importValidator = validator,
         )
 
         assertEquals(Ok(expected), actual)

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/element/ElementAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/element/ElementAllocatorImplTest.kt
@@ -1,6 +1,6 @@
 package io.github.charlietap.chasm.executor.instantiator.runtime.allocation.element
 
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.executor.instantiator.allocation.element.ElementAllocatorImpl
 import io.github.charlietap.chasm.executor.runtime.instance.ElementInstance
@@ -19,7 +19,7 @@ class ElementAllocatorImplTest {
             elements = elements,
         )
 
-        val refType = ReferenceType.RefNull(HeapType.Func)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Func)
 
         val expected = ElementInstance(
             type = refType,

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/function/HostFunctionAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/function/HostFunctionAllocatorImplTest.kt
@@ -4,6 +4,7 @@ import io.github.charlietap.chasm.executor.instantiator.allocation.function.Host
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction
 import io.github.charlietap.chasm.executor.runtime.store.Address
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.store
 import io.github.charlietap.chasm.fixture.type.functionType
 import kotlin.test.Test
@@ -23,7 +24,7 @@ class HostFunctionAllocatorImplTest {
         val hostFunction: HostFunction = { emptyList() }
 
         val expected = FunctionInstance.HostFunction(
-            type = type,
+            type = type.definedType(),
             function = hostFunction,
         )
 

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/function/WasmFunctionAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/function/WasmFunctionAllocatorImplTest.kt
@@ -7,6 +7,7 @@ import io.github.charlietap.chasm.executor.instantiator.allocation.function.Wasm
 import io.github.charlietap.chasm.executor.runtime.error.InstantiationError
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.module.function
 import io.github.charlietap.chasm.fixture.store
@@ -25,7 +26,7 @@ class WasmFunctionAllocatorImplTest {
             functions = functions,
         )
 
-        val type = functionType()
+        val type = functionType().definedType()
         val wasmFunction = function(
             typeIndex = Index.TypeIndex(0u),
         )

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/table/TableAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/table/TableAllocatorImplTest.kt
@@ -1,6 +1,6 @@
 package io.github.charlietap.chasm.executor.instantiator.runtime.allocation.table
 
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.executor.instantiator.allocation.table.TableAllocatorImpl
 import io.github.charlietap.chasm.executor.runtime.instance.TableInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
@@ -25,7 +25,7 @@ class TableAllocatorImplTest {
         val limits = limits(min.toUInt())
         val type = tableType(limits = limits)
 
-        val refValue = ReferenceValue.Null(HeapType.Func)
+        val refValue = ReferenceValue.Null(AbstractHeapType.Func)
         val elements = MutableList<ReferenceValue>(min) {
             refValue
         }

--- a/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/table/TableGrowthAllocatorImplTest.kt
+++ b/executor/instantiator/src/commonTest/kotlin/io/github/charlietap/chasm/executor/instantiator/runtime/allocation/table/TableGrowthAllocatorImplTest.kt
@@ -2,7 +2,7 @@ package io.github.charlietap.chasm.executor.instantiator.runtime.allocation.tabl
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.executor.instantiator.allocation.table.TableGrowthAllocatorAllocatorImpl
 import io.github.charlietap.chasm.executor.runtime.error.InvocationError
@@ -22,7 +22,7 @@ class TableGrowthAllocatorImplTest {
         val elementsToAdd = 2u
         val limits = limits(1u)
         val newMin = elementsToAdd + limits.min
-        val refType = ReferenceType.RefNull(HeapType.Func)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Func)
         val refVal = ReferenceValue.FunctionAddress(Address.Function(0))
         val type = tableType(refType, limits)
 
@@ -46,7 +46,7 @@ class TableGrowthAllocatorImplTest {
 
         val elementsToAdd = 2u
         val limits = limits(1u, 2u)
-        val refType = ReferenceType.RefNull(HeapType.Func)
+        val refType = ReferenceType.RefNull(AbstractHeapType.Func)
         val refVal = ReferenceValue.FunctionAddress(Address.Function(0))
         val type = tableType(refType, limits)
 

--- a/executor/invoker/build.gradle.kts
+++ b/executor/invoker/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 api(projects.ast)
                 api(projects.executor.runtime)
                 api(projects.executor.runtimeExt)
+                api(projects.executor.type)
                 api(libs.result)
 
                 implementation(projects.executor.memory)

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/FunctionInvokerImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/FunctionInvokerImpl.kt
@@ -17,6 +17,7 @@ import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.store.Store
 import io.github.charlietap.chasm.executor.runtime.value.ExecutionValue
+import io.github.charlietap.chasm.executor.type.ext.functionType
 
 fun FunctionInvokerImpl(
     store: Store,
@@ -42,9 +43,11 @@ internal fun FunctionInvokerImpl(
 
     if (index == -1) Err(InvocationError.InvalidAddress).bind<List<ExecutionValue>>()
 
+    val functionType = function.functionType().bind()
+
     val thread = Thread(
         Stack.Entry.ActivationFrame(
-            Arity(function.type.results.types.size),
+            Arity(functionType.results.types.size),
             Stack.Entry.ActivationFrame.State(
                 values.toMutableList(),
                 function.module,

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImpl.kt
@@ -3,7 +3,7 @@ package io.github.charlietap.chasm.executor.invoker.function
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ValueType
@@ -59,17 +59,17 @@ private fun classifyValue(valueType: ValueType, value: ExecutionValue?): Boolean
             when (val referenceType = valueType.referenceType) {
                 is ReferenceType.RefNull ->
                     when (referenceType.heapType) {
-                        is HeapType.Func ->
+                        is AbstractHeapType.Func ->
                             value is ReferenceValue.FunctionAddress ||
                                 value is ReferenceValue.Null && value.heapType == referenceType.heapType
-                        is HeapType.Extern ->
+                        is AbstractHeapType.Extern ->
                             value is ReferenceValue.ExternAddress ||
                                 value is ReferenceValue.Null && value.heapType == referenceType.heapType
                         else -> false
                     }
                 is ReferenceType.Ref -> when (referenceType.heapType) {
-                    is HeapType.Func -> value is ReferenceValue.FunctionAddress
-                    is HeapType.Extern -> value is ReferenceValue.ExternAddress
+                    is AbstractHeapType.Func -> value is ReferenceValue.FunctionAddress
+                    is AbstractHeapType.Extern -> value is ReferenceValue.ExternAddress
                     else -> false
                 }
             }

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImpl.kt
@@ -17,6 +17,7 @@ import io.github.charlietap.chasm.executor.runtime.value.ExecutionValue
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
 import io.github.charlietap.chasm.executor.runtime.value.VectorValue
+import io.github.charlietap.chasm.executor.type.ext.functionType
 
 @Suppress("UNUSED_PARAMETER")
 internal fun HostFunctionCallImpl(
@@ -24,7 +25,7 @@ internal fun HostFunctionCallImpl(
     stack: Stack,
     function: FunctionInstance.HostFunction,
 ): Result<Unit, InvocationError> = binding {
-    val type = function.type
+    val type = function.functionType().bind()
 
     val params = List(type.params.types.size) {
         stack.popValueOrError().bind().value

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImpl.kt
@@ -16,6 +16,7 @@ import io.github.charlietap.chasm.executor.runtime.ext.popLabelOrError
 import io.github.charlietap.chasm.executor.runtime.ext.popValueOrError
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.store.Store
+import io.github.charlietap.chasm.executor.type.ext.functionType
 
 internal inline fun WasmFunctionCallImpl(
     store: Store,
@@ -43,7 +44,7 @@ internal inline fun WasmFunctionCallImpl(
         stack.popFrameOrError().bind()
     }
 
-    val type = instance.type
+    val type = instance.functionType().bind()
 
     val params = List(type.params.types.size) {
         stack.popValueOrError().bind().value

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BlockTypeExpanderImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BlockTypeExpanderImpl.kt
@@ -9,6 +9,7 @@ import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.ResultType
 import io.github.charlietap.chasm.executor.runtime.error.InvocationError
 import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
+import io.github.charlietap.chasm.executor.type.ext.functionType
 
 internal inline fun BlockTypeExpanderImpl(
     instance: ModuleInstance,
@@ -17,7 +18,7 @@ internal inline fun BlockTypeExpanderImpl(
     when (type) {
         is ControlInstruction.BlockType.Empty -> null
         is ControlInstruction.BlockType.SignedTypeIndex -> {
-            instance.types[type.typeIndex.idx.toInt()]
+            instance.types[type.typeIndex.idx.toInt()].functionType().bind()
         }
         is ControlInstruction.BlockType.ValType -> {
             FunctionType(ResultType(emptyList()), ResultType(listOf(type.valueType)))

--- a/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImpl.kt
+++ b/executor/invoker/src/commonMain/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImpl.kt
@@ -15,9 +15,9 @@ import io.github.charlietap.chasm.executor.invoker.function.WasmFunctionCall
 import io.github.charlietap.chasm.executor.invoker.function.WasmFunctionCallImpl
 import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.error.InvocationError
+import io.github.charlietap.chasm.executor.runtime.ext.definedType
 import io.github.charlietap.chasm.executor.runtime.ext.element
 import io.github.charlietap.chasm.executor.runtime.ext.function
-import io.github.charlietap.chasm.executor.runtime.ext.functionType
 import io.github.charlietap.chasm.executor.runtime.ext.peekFrameOrError
 import io.github.charlietap.chasm.executor.runtime.ext.popI32
 import io.github.charlietap.chasm.executor.runtime.ext.table
@@ -56,7 +56,7 @@ internal inline fun CallIndirectExecutorImpl(
     val tableAddress = frame.state.module.tableAddress(tableIndex.index()).bind()
     val tableInstance = store.table(tableAddress).bind()
 
-    val functionType = frame.state.module.functionType(typeIndex.index()).bind()
+    val functionType = frame.state.module.definedType(typeIndex.index()).bind()
 
     val elementIndex = stack.popI32().bind()
     val reference = tableInstance.element(elementIndex).bind()

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/FunctionInvokerImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/FunctionInvokerImplTest.kt
@@ -14,6 +14,7 @@ import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
 import io.github.charlietap.chasm.executor.runtime.value.ExecutionValue
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.module.function
 import io.github.charlietap.chasm.fixture.store
@@ -33,9 +34,10 @@ class FunctionInvokerImplTest {
             functionAddresses = mutableListOf(address),
         )
         val functionType = functionType()
+        val definedType = functionType.definedType()
         val function = function()
         val functionInstance = FunctionInstance.WasmFunction(
-            functionType,
+            definedType,
             moduleInstance,
             function,
         )
@@ -78,9 +80,10 @@ class FunctionInvokerImplTest {
         val address = Address.Function(0)
         val moduleInstance = moduleInstance()
         val functionType = functionType()
+        val definedType = functionType.definedType()
         val function = function()
         val functionInstance = FunctionInstance.WasmFunction(
-            functionType,
+            definedType,
             moduleInstance,
             function,
         )

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/HostFunctionCallImplTest.kt
@@ -10,6 +10,7 @@ import io.github.charlietap.chasm.executor.runtime.error.InvocationError
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import io.github.charlietap.chasm.fixture.type.functionType
@@ -38,6 +39,7 @@ class HostFunctionCallImplTest {
                 ),
             ),
         )
+        val definedType = functionType.definedType()
 
         val hostFunction: HostFunction = {
             listOf(
@@ -47,7 +49,7 @@ class HostFunctionCallImplTest {
         }
 
         val functionInstance = FunctionInstance.HostFunction(
-            type = functionType,
+            type = definedType,
             function = hostFunction,
         )
 
@@ -93,6 +95,7 @@ class HostFunctionCallImplTest {
                 ),
             ),
         )
+        val definedType = functionType.definedType()
 
         val hostFunction: HostFunction = {
             listOf(
@@ -102,7 +105,7 @@ class HostFunctionCallImplTest {
         }
 
         val functionInstance = FunctionInstance.HostFunction(
-            type = functionType,
+            type = definedType,
             function = hostFunction,
         )
 

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImplTest.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.expect
 import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.instruction.NumericInstruction
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.NumberType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.ResultType
@@ -52,7 +52,7 @@ class WasmFunctionCallImplTest {
 
         val function = function(
             locals = listOf(
-                local(type = ValueType.Reference(ReferenceType.RefNull(HeapType.Func))),
+                local(type = ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func))),
             ),
             body = Expression(
                 listOf(
@@ -143,7 +143,7 @@ class WasmFunctionCallImplTest {
 
         val function = function(
             locals = listOf(
-                local(type = ValueType.Reference(ReferenceType.RefNull(HeapType.Func))),
+                local(type = ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func))),
             ),
             body = Expression(
                 listOf(
@@ -236,7 +236,7 @@ class WasmFunctionCallImplTest {
 
         val function = function(
             locals = listOf(
-                local(type = ValueType.Reference(ReferenceType.RefNull(HeapType.Func))),
+                local(type = ValueType.Reference(ReferenceType.RefNull(AbstractHeapType.Func))),
             ),
             body = Expression(
                 listOf(

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/function/WasmFunctionCallImplTest.kt
@@ -16,6 +16,7 @@ import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.ext.default
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.label
 import io.github.charlietap.chasm.fixture.module.function
@@ -49,6 +50,7 @@ class WasmFunctionCallImplTest {
                 ),
             ),
         )
+        val definedType = functionType.definedType()
 
         val function = function(
             locals = listOf(
@@ -63,7 +65,7 @@ class WasmFunctionCallImplTest {
         )
 
         val functionInstance = FunctionInstance.WasmFunction(
-            type = functionType,
+            type = definedType,
             module = moduleInstance(),
             function = function,
         )
@@ -140,6 +142,7 @@ class WasmFunctionCallImplTest {
                 ),
             ),
         )
+        val definedType = functionType.definedType()
 
         val function = function(
             locals = listOf(
@@ -154,7 +157,7 @@ class WasmFunctionCallImplTest {
         )
 
         val functionInstance = FunctionInstance.WasmFunction(
-            type = functionType,
+            type = definedType,
             module = moduleInstance(),
             function = function,
         )
@@ -233,6 +236,7 @@ class WasmFunctionCallImplTest {
                 ),
             ),
         )
+        val definedType = functionType.definedType()
 
         val function = function(
             locals = listOf(
@@ -247,7 +251,7 @@ class WasmFunctionCallImplTest {
         )
 
         val functionInstance = FunctionInstance.WasmFunction(
-            type = functionType,
+            type = definedType,
             module = moduleInstance(),
             function = function,
         )

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/InstructionExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/InstructionExecutorImplTest.kt
@@ -16,7 +16,7 @@ import io.github.charlietap.chasm.executor.invoker.instruction.parametric.Parame
 import io.github.charlietap.chasm.executor.invoker.instruction.reference.ReferenceInstructionExecutor
 import io.github.charlietap.chasm.executor.invoker.instruction.table.TableInstructionExecutor
 import io.github.charlietap.chasm.executor.invoker.instruction.variable.VariableInstructionExecutor
-import io.github.charlietap.chasm.fixture.instruction.tableIndex
+import io.github.charlietap.chasm.fixture.module.tableIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BlockTypeExpanderImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BlockTypeExpanderImplTest.kt
@@ -5,6 +5,7 @@ import io.github.charlietap.chasm.ast.instruction.ControlInstruction
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.type.functionType
 import io.github.charlietap.chasm.fixture.type.valueType
@@ -43,8 +44,9 @@ class BlockTypeExpanderImplTest {
     fun `can expand a signed type index block type`() {
         val typeIndex = Index.TypeIndex(0u)
         val type = functionType()
+        val definedType = type.definedType()
         val instance = moduleInstance(
-            types = listOf(type),
+            types = listOf(definedType),
         )
 
         val blockType = ControlInstruction.BlockType.SignedTypeIndex(typeIndex)

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BrOnNonNullExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BrOnNonNullExecutorImplTest.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ControlInstruction
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
 import io.github.charlietap.chasm.fixture.instance.functionAddress
-import io.github.charlietap.chasm.fixture.instruction.labelIndex
+import io.github.charlietap.chasm.fixture.module.labelIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.type.heapType
 import io.github.charlietap.chasm.fixture.value

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BrOnNullExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/BrOnNullExecutorImplTest.kt
@@ -4,7 +4,7 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ControlInstruction
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
 import io.github.charlietap.chasm.fixture.instance.functionAddress
-import io.github.charlietap.chasm.fixture.instruction.labelIndex
+import io.github.charlietap.chasm.fixture.module.labelIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.type.heapType
 import io.github.charlietap.chasm.fixture.value

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallExecutorImplTest.kt
@@ -9,7 +9,7 @@ import io.github.charlietap.chasm.fixture.instance.functionAddress
 import io.github.charlietap.chasm.fixture.instance.hostFunctionInstance
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.instance.wasmFunctionInstance
-import io.github.charlietap.chasm.fixture.instruction.functionIndex
+import io.github.charlietap.chasm.fixture.module.functionIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImplTest.kt
@@ -6,6 +6,7 @@ import io.github.charlietap.chasm.executor.invoker.function.WasmFunctionCall
 import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.executor.runtime.value.ReferenceValue
+import io.github.charlietap.chasm.executor.type.ext.definedType
 import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.frameState
 import io.github.charlietap.chasm.fixture.instance.functionAddress
@@ -31,8 +32,12 @@ class CallIndirectExecutorImplTest {
         val stack = stack()
 
         val typeIndex = typeIndex(0u)
-        val functionInstance = wasmFunctionInstance()
         val functionType = functionType()
+        val definedType = functionType.definedType()
+        val functionInstance = wasmFunctionInstance(
+            type = definedType,
+        )
+
         val functionAddress = functionAddress()
 
         val tableIndex = tableIndex(0u)
@@ -51,7 +56,7 @@ class CallIndirectExecutorImplTest {
         val moduleInstance = moduleInstance(
             functionAddresses = mutableListOf(functionAddress),
             tableAddresses = mutableListOf(tableAddress),
-            types = listOf(functionType),
+            types = listOf(definedType),
         )
 
         val frame = frame(
@@ -86,8 +91,11 @@ class CallIndirectExecutorImplTest {
         val stack = stack()
 
         val typeIndex = typeIndex(0u)
-        val functionInstance = hostFunctionInstance()
         val functionType = functionType()
+        val definedType = functionType.definedType()
+        val functionInstance = hostFunctionInstance(
+            type = definedType,
+        )
         val functionAddress = functionAddress()
 
         val tableIndex = tableIndex(0u)
@@ -106,7 +114,7 @@ class CallIndirectExecutorImplTest {
         val moduleInstance = moduleInstance(
             functionAddresses = mutableListOf(functionAddress),
             tableAddresses = mutableListOf(tableAddress),
-            types = listOf(functionType),
+            types = listOf(definedType),
         )
 
         val frame = frame(

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/CallIndirectExecutorImplTest.kt
@@ -14,8 +14,8 @@ import io.github.charlietap.chasm.fixture.instance.moduleInstance
 import io.github.charlietap.chasm.fixture.instance.tableAddress
 import io.github.charlietap.chasm.fixture.instance.tableInstance
 import io.github.charlietap.chasm.fixture.instance.wasmFunctionInstance
-import io.github.charlietap.chasm.fixture.instruction.tableIndex
-import io.github.charlietap.chasm.fixture.instruction.typeIndex
+import io.github.charlietap.chasm.fixture.module.tableIndex
+import io.github.charlietap.chasm.fixture.module.typeIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import io.github.charlietap.chasm.fixture.type.functionType

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/ControlInstructionExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/control/ControlInstructionExecutorImplTest.kt
@@ -4,8 +4,8 @@ import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ControlInstruction
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.executor.runtime.Stack
-import io.github.charlietap.chasm.fixture.instruction.labelIndex
-import io.github.charlietap.chasm.fixture.instruction.typeIndex
+import io.github.charlietap.chasm.fixture.module.labelIndex
+import io.github.charlietap.chasm.fixture.module.typeIndex
 import io.github.charlietap.chasm.fixture.store
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/reference/RefFuncExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/reference/RefFuncExecutorImplTest.kt
@@ -7,7 +7,7 @@ import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.frameState
 import io.github.charlietap.chasm.fixture.instance.functionAddress
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.functionIndex
+import io.github.charlietap.chasm.fixture.module.functionIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.value
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/reference/ReferenceInstructionExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/reference/ReferenceInstructionExecutorImplTest.kt
@@ -3,7 +3,7 @@ package io.github.charlietap.chasm.executor.invoker.instruction.reference
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
 import io.github.charlietap.chasm.executor.runtime.Stack
-import io.github.charlietap.chasm.fixture.instruction.functionIndex
+import io.github.charlietap.chasm.fixture.module.functionIndex
 import io.github.charlietap.chasm.fixture.type.heapType
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/GlobalGetExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/GlobalGetExecutorImplTest.kt
@@ -8,7 +8,7 @@ import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.instance.globalAddress
 import io.github.charlietap.chasm.fixture.instance.globalInstance
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.globalIndex
+import io.github.charlietap.chasm.fixture.module.globalIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/GlobalSetExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/GlobalSetExecutorImplTest.kt
@@ -8,7 +8,7 @@ import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.instance.globalAddress
 import io.github.charlietap.chasm.fixture.instance.globalInstance
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.globalIndex
+import io.github.charlietap.chasm.fixture.module.globalIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import io.github.charlietap.chasm.fixture.value

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalGetExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalGetExecutorImplTest.kt
@@ -6,7 +6,7 @@ import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.localIndex
+import io.github.charlietap.chasm.fixture.module.localIndex
 import io.github.charlietap.chasm.fixture.stack
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalSetExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalSetExecutorImplTest.kt
@@ -6,7 +6,7 @@ import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.localIndex
+import io.github.charlietap.chasm.fixture.module.localIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.value
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalTeeExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/LocalTeeExecutorImplTest.kt
@@ -6,7 +6,7 @@ import io.github.charlietap.chasm.executor.runtime.Stack
 import io.github.charlietap.chasm.executor.runtime.value.NumberValue
 import io.github.charlietap.chasm.fixture.frame
 import io.github.charlietap.chasm.fixture.instance.moduleInstance
-import io.github.charlietap.chasm.fixture.instruction.localIndex
+import io.github.charlietap.chasm.fixture.module.localIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.value
 import kotlin.test.Test

--- a/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/VariableInstructionExecutorImplTest.kt
+++ b/executor/invoker/src/commonTest/kotlin/io/github/charlietap/chasm/executor/invoker/instruction/variable/VariableInstructionExecutorImplTest.kt
@@ -2,8 +2,8 @@ package io.github.charlietap.chasm.executor.invoker.instruction.variable
 
 import com.github.michaelbull.result.Ok
 import io.github.charlietap.chasm.ast.instruction.VariableInstruction
-import io.github.charlietap.chasm.fixture.instruction.globalIndex
-import io.github.charlietap.chasm.fixture.instruction.localIndex
+import io.github.charlietap.chasm.fixture.module.globalIndex
+import io.github.charlietap.chasm.fixture.module.localIndex
 import io.github.charlietap.chasm.fixture.stack
 import io.github.charlietap.chasm.fixture.store
 import kotlin.test.Test

--- a/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/CompositeTypeExt.kt
+++ b/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/CompositeTypeExt.kt
@@ -1,0 +1,24 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.charlietap.chasm.executor.runtime.ext
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.ArrayType
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.StructType
+import io.github.charlietap.chasm.executor.runtime.error.InvocationError
+
+inline fun CompositeType.functionType(): Result<FunctionType, InvocationError> {
+    return (this as? CompositeType.Function)?.functionType?.let(::Ok) ?: Err(InvocationError.FunctionCompositeTypeExpected)
+}
+
+inline fun CompositeType.structType(): Result<StructType, InvocationError> {
+    return (this as? CompositeType.Struct)?.structType?.let(::Ok) ?: Err(InvocationError.StructCompositeTypeExpected)
+}
+
+inline fun CompositeType.arrayType(): Result<ArrayType, InvocationError> {
+    return (this as? CompositeType.Array)?.arrayType?.let(::Ok) ?: Err(InvocationError.ArrayCompositeTypeExpected)
+}

--- a/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/Ext.kt
+++ b/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/Ext.kt
@@ -1,0 +1,4 @@
+package io.github.charlietap.chasm.executor.runtime.ext
+
+infix fun <P1, IP, R> ((P1) -> IP).andThen(f: (IP) -> R): (P1) -> R =
+    { p1 -> f(this(p1)) }

--- a/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/ModuleInstanceExt.kt
+++ b/executor/runtime-ext/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/ext/ModuleInstanceExt.kt
@@ -5,13 +5,13 @@ package io.github.charlietap.chasm.executor.runtime.ext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.executor.runtime.error.InvocationError
 import io.github.charlietap.chasm.executor.runtime.instance.ExportInstance
 import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
 
-inline fun ModuleInstance.functionType(index: Int): Result<FunctionType, InvocationError.FunctionTypeLookupFailed> =
+inline fun ModuleInstance.definedType(index: Int): Result<DefinedType, InvocationError.FunctionTypeLookupFailed> =
     types.getOrNull(index)?.let(::Ok) ?: Err(InvocationError.FunctionTypeLookupFailed(index))
 
 inline fun ModuleInstance.functionAddress(index: Int): Result<Address.Function, InvocationError.FunctionAddressLookupFailed> =

--- a/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/error/InstantiationError.kt
+++ b/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/error/InstantiationError.kt
@@ -16,4 +16,6 @@ sealed interface InstantiationError : ModuleRuntimeError {
     data class UnexpectedImport(val importModuleName: String, val importEntityName: String) : InstantiationError
 
     data object DataSegmentMemoryIndexNotZero : InstantiationError
+
+    data object ClassificationError : InstantiationError
 }

--- a/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/error/InvocationError.kt
+++ b/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/error/InvocationError.kt
@@ -77,6 +77,12 @@ sealed interface InvocationError : ModuleRuntimeError {
 
     data object UndefinedDefaultReferenceType : InvocationError
 
+    data object FunctionCompositeTypeExpected : InvocationError
+
+    data object StructCompositeTypeExpected : InvocationError
+
+    data object ArrayCompositeTypeExpected : InvocationError
+
     @JvmInline
     value class UnimplementedInstruction(val instruction: Instruction) : InvocationError
 

--- a/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/instance/FunctionInstance.kt
+++ b/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/instance/FunctionInstance.kt
@@ -1,21 +1,21 @@
 package io.github.charlietap.chasm.executor.runtime.instance
 
 import io.github.charlietap.chasm.ast.module.Function
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction as HostFunctionImpl
 
 sealed class FunctionInstance {
 
-    abstract val type: FunctionType
+    abstract val type: DefinedType
 
     data class WasmFunction(
-        override val type: FunctionType,
+        override val type: DefinedType,
         val module: ModuleInstance,
         val function: Function,
     ) : FunctionInstance()
 
     data class HostFunction(
-        override val type: FunctionType,
+        override val type: DefinedType,
         val function: HostFunctionImpl,
     ) : FunctionInstance()
 }

--- a/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/instance/ModuleInstance.kt
+++ b/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/instance/ModuleInstance.kt
@@ -1,10 +1,10 @@
 package io.github.charlietap.chasm.executor.runtime.instance
 
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.executor.runtime.store.Address
 
 data class ModuleInstance(
-    val types: List<FunctionType>,
+    val types: List<DefinedType>,
     val functionAddresses: MutableList<Address.Function> = mutableListOf(),
     val tableAddresses: MutableList<Address.Table> = mutableListOf(),
     val memAddresses: MutableList<Address.Memory> = mutableListOf(),

--- a/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/type/ExternalType.kt
+++ b/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/executor/runtime/type/ExternalType.kt
@@ -1,6 +1,6 @@
 package io.github.charlietap.chasm.executor.runtime.type
 
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.ast.type.GlobalType
 import io.github.charlietap.chasm.ast.type.MemoryType
 import io.github.charlietap.chasm.ast.type.TableType
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
 
 sealed interface ExternalType {
     @JvmInline
-    value class Function(val functionType: FunctionType) : ExternalType
+    value class Function(val definedType: DefinedType) : ExternalType
 
     @JvmInline
     value class Table(val tableType: TableType) : ExternalType

--- a/executor/type/build.gradle.kts
+++ b/executor/type/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.atomic.fu)
+    id("kmp-conventions")
+    id("linting-conventions")
+    id("publishing-conventions")
+}
+
+kotlin {
+
+    sourceSets {
+
+        all {
+            languageSettings {
+                optIn("kotlin.ExperimentalUnsignedTypes")
+            }
+        }
+
+        commonMain {
+            dependencies {
+                api(projects.ast)
+                api(projects.executor.runtime)
+                api(projects.executor.runtimeExt)
+                api(libs.result)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(projects.test.fixture.ast)
+                implementation(projects.test.fixture.executor.runtime)
+                implementation(libs.kotlin.test)
+            }
+        }
+    }
+}
+
+configure<PublishingConventionsExtension> {
+    name = "type"
+    description = "chasms runtime type operations"
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = libs.versions.java.bytecode.version.get()
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/expansion/DefinedTypeExpander.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/expansion/DefinedTypeExpander.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.executor.type.expansion
+
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.DefinedType
+
+typealias DefinedTypeExpander = (DefinedType) -> CompositeType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/expansion/DefinedTypeExpanderImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/expansion/DefinedTypeExpanderImpl.kt
@@ -1,0 +1,19 @@
+package io.github.charlietap.chasm.executor.type.expansion
+
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeUnroller
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeUnrollerImpl
+
+fun DefinedTypeExpanderImpl(
+    definedType: DefinedType,
+): CompositeType =
+    DefinedTypeExpanderImpl(
+        definedType = definedType,
+        definedTypeUnroller = ::DefinedTypeUnrollerImpl,
+    )
+
+internal fun DefinedTypeExpanderImpl(
+    definedType: DefinedType,
+    definedTypeUnroller: DefinedTypeUnroller,
+): CompositeType = definedTypeUnroller(definedType).compositeType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/DefinedTypeExt.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/DefinedTypeExt.kt
@@ -1,0 +1,15 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.charlietap.chasm.executor.type.ext
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.executor.runtime.error.InvocationError
+import io.github.charlietap.chasm.executor.runtime.ext.functionType
+import io.github.charlietap.chasm.executor.type.expansion.DefinedTypeExpander
+import io.github.charlietap.chasm.executor.type.expansion.DefinedTypeExpanderImpl
+
+inline fun DefinedType.functionType(
+    definedTypeExpander: DefinedTypeExpander = ::DefinedTypeExpanderImpl,
+): Result<FunctionType, InvocationError> = definedTypeExpander(this).functionType()

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/FunctionInstanceExt.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/FunctionInstanceExt.kt
@@ -1,0 +1,11 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.charlietap.chasm.executor.type.ext
+
+import com.github.michaelbull.result.Result
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.executor.runtime.error.InvocationError
+import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
+
+inline fun FunctionInstance.functionType(): Result<FunctionType, InvocationError> =
+    type.functionType()

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/FunctionTypeExt.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/FunctionTypeExt.kt
@@ -1,0 +1,21 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.charlietap.chasm.executor.type.ext
+
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.ast.type.SubType
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRoller
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRollerImpl
+
+inline fun FunctionType.recursiveType() = RecursiveType(
+    listOf(
+        SubType.Final(emptyList(), CompositeType.Function(this)),
+    ),
+)
+
+inline fun FunctionType.definedType(
+    definedTypeRoller: DefinedTypeRoller = ::DefinedTypeRollerImpl,
+): DefinedType = definedTypeRoller(0, this.recursiveType()).first()

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/RecursiveTypeExt.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/ext/RecursiveTypeExt.kt
@@ -1,0 +1,12 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package io.github.charlietap.chasm.executor.type.ext
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRoller
+import io.github.charlietap.chasm.executor.type.rolling.DefinedTypeRollerImpl
+
+inline fun RecursiveType.definedType(
+    definedTypeRoller: DefinedTypeRoller = ::DefinedTypeRollerImpl,
+): DefinedType = definedTypeRoller(0, this).first()

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeRoller.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeRoller.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+typealias DefinedTypeRoller = (Int, RecursiveType) -> List<DefinedType>

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeRollerImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeRollerImpl.kt
@@ -1,0 +1,25 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+fun DefinedTypeRollerImpl(
+    index: Int,
+    recursiveType: RecursiveType,
+): List<DefinedType> =
+    DefinedTypeRollerImpl(
+        index = index,
+        recursiveType = recursiveType,
+        recursiveTypeRoller = ::RecursiveTypeRollerImpl,
+    )
+
+internal fun DefinedTypeRollerImpl(
+    index: Int,
+    recursiveType: RecursiveType,
+    recursiveTypeRoller: RecursiveTypeRoller,
+): List<DefinedType> {
+    val rolledRecursiveType = recursiveTypeRoller(index, recursiveType)
+    return List(rolledRecursiveType.subTypes.size) { subTypeIndex ->
+        DefinedType(rolledRecursiveType, subTypeIndex)
+    }
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeUnroller.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeUnroller.kt
@@ -1,0 +1,6 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.SubType
+
+typealias DefinedTypeUnroller = (DefinedType) -> SubType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeUnrollerImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/DefinedTypeUnrollerImpl.kt
@@ -1,0 +1,20 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.SubType
+
+fun DefinedTypeUnrollerImpl(
+    definedType: DefinedType,
+): SubType =
+    DefinedTypeUnrollerImpl(
+        definedType = definedType,
+        recursiveTypeUnroller = ::RecursiveTypeUnrollerImpl,
+    )
+
+internal fun DefinedTypeUnrollerImpl(
+    definedType: DefinedType,
+    recursiveTypeUnroller: RecursiveTypeUnroller,
+): SubType {
+    val unrolledRecursiveType = recursiveTypeUnroller(definedType.recursiveType)
+    return unrolledRecursiveType.subTypes[definedType.recursiveTypeIndex]
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeRoller.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeRoller.kt
@@ -1,0 +1,5 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+typealias RecursiveTypeRoller = (Int, RecursiveType) -> RecursiveType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeRollerImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeRollerImpl.kt
@@ -1,0 +1,39 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.executor.type.rolling.substitution.ConcreteHeapTypeSubstitutor
+import io.github.charlietap.chasm.executor.type.rolling.substitution.RecursiveTypeSubstitutorImpl
+import io.github.charlietap.chasm.executor.type.rolling.substitution.TypeSubstitutor
+
+fun RecursiveTypeRollerImpl(
+    index: Int,
+    recursiveType: RecursiveType,
+): RecursiveType =
+    RecursiveTypeRollerImpl(
+        index = index,
+        recursiveType = recursiveType,
+        recursiveTypeSubstitutor = ::RecursiveTypeSubstitutorImpl,
+    )
+
+internal fun RecursiveTypeRollerImpl(
+    index: Int,
+    recursiveType: RecursiveType,
+    recursiveTypeSubstitutor: TypeSubstitutor<RecursiveType>,
+): RecursiveType {
+    val recursiveIndexUpperBound = index + recursiveType.subTypes.size
+    val substitutor: ConcreteHeapTypeSubstitutor = { heapType ->
+        when (heapType) {
+            is ConcreteHeapType.TypeIndex -> {
+                val typeIndex = heapType.index.idx.toInt()
+                if (typeIndex in index..<recursiveIndexUpperBound) {
+                    ConcreteHeapType.RecursiveTypeIndex(typeIndex - index)
+                } else {
+                    heapType
+                }
+            }
+            else -> heapType
+        }
+    }
+    return recursiveTypeSubstitutor(recursiveType, substitutor)
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeUnroller.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeUnroller.kt
@@ -1,0 +1,5 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+typealias RecursiveTypeUnroller = (RecursiveType) -> RecursiveType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeUnrollerImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/RecursiveTypeUnrollerImpl.kt
@@ -1,0 +1,31 @@
+package io.github.charlietap.chasm.executor.type.rolling
+
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.executor.type.rolling.substitution.ConcreteHeapTypeSubstitutor
+import io.github.charlietap.chasm.executor.type.rolling.substitution.RecursiveTypeSubstitutorImpl
+import io.github.charlietap.chasm.executor.type.rolling.substitution.TypeSubstitutor
+
+fun RecursiveTypeUnrollerImpl(
+    recursiveType: RecursiveType,
+): RecursiveType =
+    RecursiveTypeUnrollerImpl(
+        recursiveType = recursiveType,
+        recursiveTypeSubstitutor = ::RecursiveTypeSubstitutorImpl,
+    )
+
+internal fun RecursiveTypeUnrollerImpl(
+    recursiveType: RecursiveType,
+    recursiveTypeSubstitutor: TypeSubstitutor<RecursiveType>,
+): RecursiveType {
+    val substitutor: ConcreteHeapTypeSubstitutor = { heapType ->
+        when (heapType) {
+            is ConcreteHeapType.RecursiveTypeIndex -> ConcreteHeapType.Defined(
+                DefinedType(recursiveType, heapType.index),
+            )
+            else -> heapType
+        }
+    }
+    return recursiveTypeSubstitutor(recursiveType, substitutor)
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ArrayTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ArrayTypeSubstitutorImpl.kt
@@ -1,0 +1,22 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ArrayType
+import io.github.charlietap.chasm.ast.type.FieldType
+
+internal fun ArrayTypeSubstitutorImpl(
+    arrayType: ArrayType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): ArrayType =
+    ArrayTypeSubstitutorImpl(
+        arrayType = arrayType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        fieldTypeSubstitutor = ::FieldTypeSubstitutorImpl,
+    )
+
+internal fun ArrayTypeSubstitutorImpl(
+    arrayType: ArrayType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    fieldTypeSubstitutor: TypeSubstitutor<FieldType>,
+): ArrayType = ArrayType(
+    fieldTypeSubstitutor(arrayType.field, concreteHeapTypeSubstitutor),
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/CompositeTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/CompositeTypeSubstitutorImpl.kt
@@ -1,0 +1,36 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ArrayType
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.StructType
+
+internal fun CompositeTypeSubstitutorImpl(
+    compositeType: CompositeType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): CompositeType =
+    CompositeTypeSubstitutorImpl(
+        compositeType = compositeType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        structTypeSubstitutor = ::StructTypeSubstitutorImpl,
+        arrayTypeSubstitutor = ::ArrayTypeSubstitutorImpl,
+        functionTypeSubstitutor = ::FunctionTypeSubstitutorImpl,
+    )
+
+internal fun CompositeTypeSubstitutorImpl(
+    compositeType: CompositeType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    structTypeSubstitutor: TypeSubstitutor<StructType>,
+    arrayTypeSubstitutor: TypeSubstitutor<ArrayType>,
+    functionTypeSubstitutor: TypeSubstitutor<FunctionType>,
+): CompositeType = when (compositeType) {
+    is CompositeType.Struct -> CompositeType.Struct(
+        structTypeSubstitutor(compositeType.structType, concreteHeapTypeSubstitutor),
+    )
+    is CompositeType.Array -> CompositeType.Array(
+        arrayTypeSubstitutor(compositeType.arrayType, concreteHeapTypeSubstitutor),
+    )
+    is CompositeType.Function -> CompositeType.Function(
+        functionTypeSubstitutor(compositeType.functionType, concreteHeapTypeSubstitutor),
+    )
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ConcreteHeapTypeSubstitutor.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ConcreteHeapTypeSubstitutor.kt
@@ -1,0 +1,5 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+
+typealias ConcreteHeapTypeSubstitutor = (ConcreteHeapType) -> ConcreteHeapType

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/DefinedTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/DefinedTypeSubstitutorImpl.kt
@@ -1,0 +1,22 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+fun DefinedTypeSubstitutorImpl(
+    definedType: DefinedType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): DefinedType =
+    DefinedTypeSubstitutorImpl(
+        definedType = definedType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        recursiveTypeSubstitutor = ::RecursiveTypeSubstitutorImpl,
+    )
+
+internal fun DefinedTypeSubstitutorImpl(
+    definedType: DefinedType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    recursiveTypeSubstitutor: TypeSubstitutor<RecursiveType>,
+): DefinedType = definedType.copy(
+    recursiveTypeSubstitutor(definedType.recursiveType, concreteHeapTypeSubstitutor),
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/FieldTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/FieldTypeSubstitutorImpl.kt
@@ -1,0 +1,22 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StorageType
+
+internal fun FieldTypeSubstitutorImpl(
+    fieldType: FieldType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): FieldType =
+    FieldTypeSubstitutorImpl(
+        fieldType = fieldType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        storageTypeSubstitutor = ::StorageTypeSubstitutorImpl,
+    )
+
+internal fun FieldTypeSubstitutorImpl(
+    fieldType: FieldType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    storageTypeSubstitutor: TypeSubstitutor<StorageType>,
+): FieldType = fieldType.copy(
+    storageTypeSubstitutor(fieldType.storageType, concreteHeapTypeSubstitutor),
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/FunctionTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/FunctionTypeSubstitutorImpl.kt
@@ -1,0 +1,24 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.ResultType
+
+internal fun FunctionTypeSubstitutorImpl(
+    functionType: FunctionType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): FunctionType =
+    FunctionTypeSubstitutorImpl(
+        functionType = functionType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        resultTypeSubstitutor = ::ResultTypeSubstitutorImpl,
+    )
+
+internal fun FunctionTypeSubstitutorImpl(
+    functionType: FunctionType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    resultTypeSubstitutor: TypeSubstitutor<ResultType>,
+): FunctionType {
+    val params = resultTypeSubstitutor(functionType.params, concreteHeapTypeSubstitutor)
+    val results = resultTypeSubstitutor(functionType.results, concreteHeapTypeSubstitutor)
+    return FunctionType(params, results)
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/HeapTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/HeapTypeSubstitutorImpl.kt
@@ -1,0 +1,12 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.ast.type.HeapType
+
+internal fun HeapTypeSubstitutorImpl(
+    heapType: HeapType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): HeapType = when (heapType) {
+    is ConcreteHeapType -> concreteHeapTypeSubstitutor(heapType)
+    else -> heapType
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/RecursiveTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/RecursiveTypeSubstitutorImpl.kt
@@ -1,0 +1,24 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.ast.type.SubType
+
+internal fun RecursiveTypeSubstitutorImpl(
+    recursiveType: RecursiveType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): RecursiveType =
+    RecursiveTypeSubstitutorImpl(
+        recursiveType = recursiveType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        subTypeSubstitutor = ::SubTypeSubstitutorImpl,
+    )
+
+internal fun RecursiveTypeSubstitutorImpl(
+    recursiveType: RecursiveType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    subTypeSubstitutor: TypeSubstitutor<SubType>,
+): RecursiveType = RecursiveType(
+    recursiveType.subTypes.map { subType ->
+        subTypeSubstitutor(subType, concreteHeapTypeSubstitutor)
+    },
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ReferenceTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ReferenceTypeSubstitutorImpl.kt
@@ -1,0 +1,26 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.ReferenceType
+
+internal fun ReferenceTypeSubstitutorImpl(
+    referenceType: ReferenceType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): ReferenceType =
+    ReferenceTypeSubstitutorImpl(
+        referenceType = referenceType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        heapTypeSubstitutor = ::HeapTypeSubstitutorImpl,
+    )
+
+internal fun ReferenceTypeSubstitutorImpl(
+    referenceType: ReferenceType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    heapTypeSubstitutor: TypeSubstitutor<HeapType>,
+): ReferenceType {
+    val heapType = heapTypeSubstitutor(referenceType.heapType, concreteHeapTypeSubstitutor)
+    return when (referenceType) {
+        is ReferenceType.Ref -> ReferenceType.Ref(heapType)
+        is ReferenceType.RefNull -> ReferenceType.RefNull(heapType)
+    }
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ResultTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ResultTypeSubstitutorImpl.kt
@@ -1,0 +1,24 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ResultType
+import io.github.charlietap.chasm.ast.type.ValueType
+
+internal fun ResultTypeSubstitutorImpl(
+    resultType: ResultType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): ResultType =
+    ResultTypeSubstitutorImpl(
+        resultType = resultType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        valueTypeSubstitutor = ::ValueTypeSubstitutorImpl,
+    )
+
+internal fun ResultTypeSubstitutorImpl(
+    resultType: ResultType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    valueTypeSubstitutor: TypeSubstitutor<ValueType>,
+): ResultType = ResultType(
+    resultType.types.map { valueType ->
+        valueTypeSubstitutor(valueType, concreteHeapTypeSubstitutor)
+    },
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/StorageTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/StorageTypeSubstitutorImpl.kt
@@ -1,0 +1,25 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.ast.type.ValueType
+
+internal fun StorageTypeSubstitutorImpl(
+    storageType: StorageType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): StorageType =
+    StorageTypeSubstitutorImpl(
+        storageType = storageType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        valueTypeSubstitutor = ::ValueTypeSubstitutorImpl,
+    )
+
+internal fun StorageTypeSubstitutorImpl(
+    storageType: StorageType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    valueTypeSubstitutor: TypeSubstitutor<ValueType>,
+): StorageType = when (storageType) {
+    is StorageType.Packed -> storageType
+    is StorageType.Value -> {
+        StorageType.Value(valueTypeSubstitutor(storageType.type, concreteHeapTypeSubstitutor))
+    }
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/StructTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/StructTypeSubstitutorImpl.kt
@@ -1,0 +1,24 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StructType
+
+internal fun StructTypeSubstitutorImpl(
+    structType: StructType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): StructType =
+    StructTypeSubstitutorImpl(
+        structType = structType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        fieldTypeSubstitutor = ::FieldTypeSubstitutorImpl,
+    )
+
+internal fun StructTypeSubstitutorImpl(
+    structType: StructType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    fieldTypeSubstitutor: TypeSubstitutor<FieldType>,
+): StructType = StructType(
+    structType.fields.map { fieldType ->
+        fieldTypeSubstitutor(fieldType, concreteHeapTypeSubstitutor)
+    },
+)

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/SubTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/SubTypeSubstitutorImpl.kt
@@ -1,0 +1,40 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.SubType
+
+internal fun SubTypeSubstitutorImpl(
+    subType: SubType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): SubType =
+    SubTypeSubstitutorImpl(
+        subType = subType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        heapTypeSubstitutor = ::HeapTypeSubstitutorImpl,
+        compositeTypeSubstitutor = ::CompositeTypeSubstitutorImpl,
+    )
+
+internal fun SubTypeSubstitutorImpl(
+    subType: SubType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    heapTypeSubstitutor: TypeSubstitutor<HeapType>,
+    compositeTypeSubstitutor: TypeSubstitutor<CompositeType>,
+): SubType = when (subType) {
+    is SubType.Open -> subType.copy(
+        superTypes = subType.superTypes.map { heapType ->
+            heapTypeSubstitutor(heapType, concreteHeapTypeSubstitutor)
+        },
+        compositeType = subType.compositeType.let { compositeType ->
+            compositeTypeSubstitutor(compositeType, concreteHeapTypeSubstitutor)
+        },
+    )
+    is SubType.Final -> subType.copy(
+        superTypes = subType.superTypes.map { heapType ->
+            heapTypeSubstitutor(heapType, concreteHeapTypeSubstitutor)
+        },
+        compositeType = subType.compositeType.let { compositeType ->
+            compositeTypeSubstitutor(compositeType, concreteHeapTypeSubstitutor)
+        },
+    )
+}

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/TypeSubstitutor.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/TypeSubstitutor.kt
@@ -1,0 +1,3 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+typealias TypeSubstitutor<T> = (T, ConcreteHeapTypeSubstitutor) -> T

--- a/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ValueTypeSubstitutorImpl.kt
+++ b/executor/type/src/commonMain/kotlin/io/github/charlietap/chasm/executor/type/rolling/substitution/ValueTypeSubstitutorImpl.kt
@@ -1,0 +1,32 @@
+package io.github.charlietap.chasm.executor.type.rolling.substitution
+
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.ast.type.ValueType
+
+internal fun ValueTypeSubstitutorImpl(
+    valueType: ValueType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+): ValueType =
+    ValueTypeSubstitutorImpl(
+        valueType = valueType,
+        concreteHeapTypeSubstitutor = concreteHeapTypeSubstitutor,
+        referenceTypeSubstitutor = ::ReferenceTypeSubstitutorImpl,
+    )
+
+internal fun ValueTypeSubstitutorImpl(
+    valueType: ValueType,
+    concreteHeapTypeSubstitutor: ConcreteHeapTypeSubstitutor,
+    referenceTypeSubstitutor: TypeSubstitutor<ReferenceType>,
+): ValueType = when (valueType) {
+    is ValueType.Number,
+    is ValueType.Vector,
+    -> valueType
+    is ValueType.Reference -> {
+        ValueType.Reference(
+            referenceTypeSubstitutor(
+                valueType.referenceType,
+                concreteHeapTypeSubstitutor,
+            ),
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,6 +47,7 @@ include(":executor:invoker")
 include(":executor:memory")
 include(":executor:runtime")
 include(":executor:runtime-ext")
+include(":executor:type")
 
 include(":test:fake:decoder")
 

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/ControlInstruction.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/ControlInstruction.kt
@@ -1,0 +1,23 @@
+package io.github.charlietap.chasm.fixture.instruction
+
+import io.github.charlietap.chasm.ast.instruction.ControlInstruction
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.fixture.module.labelIndex
+import io.github.charlietap.chasm.fixture.type.referenceType
+
+fun controlInstruction() = unreachableInstruction()
+
+fun unreachableInstruction() = ControlInstruction.Unreachable
+
+fun prefixedControlInstruction() = brOnCastInstruction()
+
+fun brOnCastInstruction(
+    labelIndex: Index.LabelIndex = labelIndex(),
+    srcReferenceType: ReferenceType = referenceType(),
+    dstReferenceType: ReferenceType = referenceType(),
+) = ControlInstruction.BrOnCast(
+    labelIndex = labelIndex,
+    srcReferenceType = srcReferenceType,
+    dstReferenceType = dstReferenceType,
+)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/Index.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/Index.kt
@@ -37,3 +37,7 @@ fun tableIndex(
 fun typeIndex(
     index: UInt = 0u,
 ) = Index.TypeIndex(index)
+
+fun fieldIndex(
+    index: UInt = 0u,
+) = Index.FieldIndex(index)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/ReferenceInstruction.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instruction/ReferenceInstruction.kt
@@ -1,0 +1,17 @@
+package io.github.charlietap.chasm.fixture.instruction
+
+import io.github.charlietap.chasm.ast.instruction.ReferenceInstruction
+import io.github.charlietap.chasm.ast.type.ReferenceType
+import io.github.charlietap.chasm.fixture.type.referenceType
+
+fun referenceInstruction() = refEqInstruction()
+
+fun refEqInstruction() = ReferenceInstruction.RefEq
+
+fun prefixedReferenceInstruction() = refTest()
+
+fun refTest(
+    referenceType: ReferenceType = referenceType(),
+) = ReferenceInstruction.RefTest(
+    referenceType = referenceType,
+)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/ElementSegment.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/ElementSegment.kt
@@ -3,12 +3,12 @@ package io.github.charlietap.chasm.fixture.module
 import io.github.charlietap.chasm.ast.instruction.Expression
 import io.github.charlietap.chasm.ast.module.ElementSegment
 import io.github.charlietap.chasm.ast.module.Index
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 
 fun elementSegment(
     idx: Index.ElementIndex = Index.ElementIndex(0u),
-    type: ReferenceType = ReferenceType.RefNull(HeapType.Func),
+    type: ReferenceType = ReferenceType.RefNull(AbstractHeapType.Func),
     initExpressions: List<Expression> = emptyList(),
     mode: ElementSegment.Mode = ElementSegment.Mode.Passive,
 ) = ElementSegment(

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Import.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Import.kt
@@ -11,7 +11,7 @@ import io.github.charlietap.chasm.fixture.type.memoryType
 import io.github.charlietap.chasm.fixture.type.tableType
 
 fun functionImportDescriptor(
-    typeIndex: Index.TypeIndex = Index.TypeIndex(0u),
+    typeIndex: Index.TypeIndex = typeIndex(),
 ) = Import.Descriptor.Function(
     typeIndex = typeIndex,
 )

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Index.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Index.kt
@@ -1,4 +1,4 @@
-package io.github.charlietap.chasm.fixture.instruction
+package io.github.charlietap.chasm.fixture.module
 
 import io.github.charlietap.chasm.ast.module.Index
 

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Type.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/module/Type.kt
@@ -2,13 +2,13 @@ package io.github.charlietap.chasm.fixture.module
 
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.module.Type
-import io.github.charlietap.chasm.ast.type.FunctionType
-import io.github.charlietap.chasm.fixture.type.functionType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.fixture.type.recursiveType
 
 fun type(
-    idx: Index.TypeIndex = Index.TypeIndex(0u),
-    functionType: FunctionType = functionType(),
+    idx: Index.TypeIndex = typeIndex(),
+    recursiveType: RecursiveType = recursiveType(),
 ) = Type(
     idx = idx,
-    functionType = functionType,
+    recursiveType = recursiveType,
 )

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ArrayType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ArrayType.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.ArrayType
+import io.github.charlietap.chasm.ast.type.FieldType
+
+fun arrayType(
+    field: FieldType = fieldType(),
+) = ArrayType(field)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/CompositeType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/CompositeType.kt
@@ -1,8 +1,9 @@
 package io.github.charlietap.chasm.fixture.type
 
+import io.github.charlietap.chasm.ast.type.ArrayType
 import io.github.charlietap.chasm.ast.type.CompositeType
-import io.github.charlietap.chasm.ast.type.FieldType
 import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.StructType
 
 fun compositeType() = functionCompositeType()
 
@@ -11,9 +12,9 @@ fun functionCompositeType(
 ) = CompositeType.Function(functionType)
 
 fun structCompositeType(
-    fields: List<FieldType> = emptyList(),
-) = CompositeType.Struct(fields)
+    structType: StructType = structType(),
+) = CompositeType.Struct(structType)
 
 fun arrayCompositeType(
-    field: FieldType = fieldType(),
-) = CompositeType.Array(field)
+    arrayType: ArrayType = arrayType(),
+) = CompositeType.Array(arrayType)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/CompositeType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/CompositeType.kt
@@ -1,0 +1,19 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.FunctionType
+
+fun compositeType() = functionCompositeType()
+
+fun functionCompositeType(
+    functionType: FunctionType = functionType(),
+) = CompositeType.Function(functionType)
+
+fun structCompositeType(
+    fields: List<FieldType> = emptyList(),
+) = CompositeType.Struct(fields)
+
+fun arrayCompositeType(
+    field: FieldType = fieldType(),
+) = CompositeType.Array(field)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/DefinedType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/DefinedType.kt
@@ -1,0 +1,9 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.RecursiveType
+
+fun definedType(
+    recursiveType: RecursiveType = recursiveType(),
+    recursiveTypeIndex: Int = 0,
+) = DefinedType(recursiveType, recursiveTypeIndex)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/FieldType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/FieldType.kt
@@ -1,14 +1,17 @@
 package io.github.charlietap.chasm.fixture.type
 
 import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.StorageType
 
 fun fieldType() = immutableFieldType()
 
 fun mutableFieldType(
     storageType: StorageType = storageType(),
-) = FieldType.MutableStorageType(storageType)
+    mutability: Mutability = mutability(),
+) = FieldType(storageType, mutability)
 
 fun immutableFieldType(
     storageType: StorageType = storageType(),
-) = FieldType.ImmutableStorageType(storageType)
+    mutability: Mutability = mutability(),
+) = FieldType(storageType, mutability)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/FieldType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/FieldType.kt
@@ -1,0 +1,14 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StorageType
+
+fun fieldType() = immutableFieldType()
+
+fun mutableFieldType(
+    storageType: StorageType = storageType(),
+) = FieldType.MutableStorageType(storageType)
+
+fun immutableFieldType(
+    storageType: StorageType = storageType(),
+) = FieldType.ImmutableStorageType(storageType)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/GlobalType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/GlobalType.kt
@@ -1,11 +1,12 @@
 package io.github.charlietap.chasm.fixture.type
 
 import io.github.charlietap.chasm.ast.type.GlobalType
+import io.github.charlietap.chasm.ast.type.Mutability
 import io.github.charlietap.chasm.ast.type.ValueType
 
 fun globalType(
     valueType: ValueType = valueType(),
-    mutability: GlobalType.Mutability = GlobalType.Mutability.Var,
+    mutability: Mutability = mutability(),
 ) = GlobalType(
     valueType = valueType,
     mutability = mutability,

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
@@ -3,12 +3,26 @@ package io.github.charlietap.chasm.fixture.type
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.fixture.module.typeIndex
 
-fun heapType() = abstractHeapType()
+fun heapType(): HeapType = abstractHeapType()
 
-fun abstractHeapType() = AbstractHeapType.Func
+fun abstractHeapType(): AbstractHeapType = functionHeapType()
 
-fun concreteHeapType(
+fun functionHeapType() = AbstractHeapType.Func
+
+fun concreteHeapType(): ConcreteHeapType = concreteTypeIndexHeapType()
+
+fun concreteTypeIndexHeapType(
     typeIndex: Index.TypeIndex = typeIndex(),
-) = ConcreteHeapType(typeIndex)
+) = ConcreteHeapType.TypeIndex(typeIndex)
+
+fun concreteRecursiveTypeIndexHeapType(
+    recursiveTypeIndex: Int = 0,
+) = ConcreteHeapType.RecursiveTypeIndex(recursiveTypeIndex)
+
+fun concreteDefinedTypeHeapType(
+    definedType: DefinedType = definedType(),
+) = ConcreteHeapType.Defined(definedType)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
@@ -3,7 +3,7 @@ package io.github.charlietap.chasm.fixture.type
 import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.ConcreteHeapType
-import io.github.charlietap.chasm.fixture.instruction.typeIndex
+import io.github.charlietap.chasm.fixture.module.typeIndex
 
 fun heapType() = abstractHeapType()
 

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/HeapType.kt
@@ -1,5 +1,14 @@
 package io.github.charlietap.chasm.fixture.type
 
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
+import io.github.charlietap.chasm.ast.type.ConcreteHeapType
+import io.github.charlietap.chasm.fixture.instruction.typeIndex
 
-fun heapType() = HeapType.Func
+fun heapType() = abstractHeapType()
+
+fun abstractHeapType() = AbstractHeapType.Func
+
+fun concreteHeapType(
+    typeIndex: Index.TypeIndex = typeIndex(),
+) = ConcreteHeapType(typeIndex)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/Mutability.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/Mutability.kt
@@ -1,0 +1,5 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.Mutability
+
+fun mutability() = Mutability.Const

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/PackedType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/PackedType.kt
@@ -1,0 +1,13 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.PackedType
+
+fun packedType() = i8PackedType()
+
+fun i8PackedType(
+    value: Byte = 0,
+) = PackedType.I8(value)
+
+fun i16PackedType(
+    value: Short = 0,
+) = PackedType.I16(value)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/PackedType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/PackedType.kt
@@ -4,10 +4,6 @@ import io.github.charlietap.chasm.ast.type.PackedType
 
 fun packedType() = i8PackedType()
 
-fun i8PackedType(
-    value: Byte = 0,
-) = PackedType.I8(value)
+fun i8PackedType() = PackedType.I8
 
-fun i16PackedType(
-    value: Short = 0,
-) = PackedType.I16(value)
+fun i16PackedType() = PackedType.I16

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/RecursiveType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/RecursiveType.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.RecursiveType
+import io.github.charlietap.chasm.ast.type.SubType
+
+fun recursiveType(
+    subTypes: List<SubType>,
+) = RecursiveType(subTypes)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/RecursiveType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/RecursiveType.kt
@@ -1,8 +1,18 @@
 package io.github.charlietap.chasm.fixture.type
 
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.FunctionType
 import io.github.charlietap.chasm.ast.type.RecursiveType
 import io.github.charlietap.chasm.ast.type.SubType
 
 fun recursiveType(
-    subTypes: List<SubType>,
+    subTypes: List<SubType> = emptyList(),
 ) = RecursiveType(subTypes)
+
+fun functionRecursiveType(
+    functionType: FunctionType = functionType(),
+) = RecursiveType(
+    listOf(
+        SubType.Final(emptyList(), CompositeType.Function(functionType)),
+    ),
+)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ReferenceType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ReferenceType.kt
@@ -3,4 +3,12 @@ package io.github.charlietap.chasm.fixture.type
 import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.ReferenceType
 
-fun referenceType() = ReferenceType.RefNull(HeapType.Func)
+fun referenceType() = refNullReferenceType()
+
+fun refNullReferenceType(
+    heapType: HeapType = heapType(),
+) = ReferenceType.RefNull(heapType)
+
+fun refNonNullReferenceType(
+    heapType: HeapType = heapType(),
+) = ReferenceType.Ref(heapType)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/StorageType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/StorageType.kt
@@ -1,0 +1,15 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.PackedType
+import io.github.charlietap.chasm.ast.type.StorageType
+import io.github.charlietap.chasm.ast.type.ValueType
+
+fun storageType() = packedStorageType()
+
+fun packedStorageType(
+    packedType: PackedType = packedType(),
+) = StorageType.Packed(packedType)
+
+fun valueStorageType(
+    valueType: ValueType = valueType(),
+) = StorageType.Value(valueType)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/StructType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/StructType.kt
@@ -1,0 +1,8 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.FieldType
+import io.github.charlietap.chasm.ast.type.StructType
+
+fun structType(
+    fields: List<FieldType> = emptyList(),
+) = StructType(fields)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/SubType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/SubType.kt
@@ -1,23 +1,23 @@
 package io.github.charlietap.chasm.fixture.type
 
-import io.github.charlietap.chasm.ast.module.Index
 import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.HeapType
 import io.github.charlietap.chasm.ast.type.SubType
 
 fun subType() = openSubType()
 
 fun openSubType(
-    typeIndices: List<Index.TypeIndex> = emptyList(),
+    heapTypes: List<HeapType> = emptyList(),
     compositeType: CompositeType = compositeType(),
 ) = SubType.Open(
-    typeIndices,
+    heapTypes,
     compositeType,
 )
 
 fun finalSubType(
-    typeIndices: List<Index.TypeIndex> = emptyList(),
+    heapTypes: List<HeapType> = emptyList(),
     compositeType: CompositeType = compositeType(),
 ) = SubType.Final(
-    typeIndices,
+    heapTypes,
     compositeType,
 )

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/SubType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/SubType.kt
@@ -1,0 +1,23 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.module.Index
+import io.github.charlietap.chasm.ast.type.CompositeType
+import io.github.charlietap.chasm.ast.type.SubType
+
+fun subType() = openSubType()
+
+fun openSubType(
+    typeIndices: List<Index.TypeIndex> = emptyList(),
+    compositeType: CompositeType = compositeType(),
+) = SubType.Open(
+    typeIndices,
+    compositeType,
+)
+
+fun finalSubType(
+    typeIndices: List<Index.TypeIndex> = emptyList(),
+    compositeType: CompositeType = compositeType(),
+) = SubType.Final(
+    typeIndices,
+    compositeType,
+)

--- a/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/TableType.kt
+++ b/test/fixture/ast/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/TableType.kt
@@ -1,12 +1,12 @@
 package io.github.charlietap.chasm.fixture.type
 
-import io.github.charlietap.chasm.ast.type.HeapType
+import io.github.charlietap.chasm.ast.type.AbstractHeapType
 import io.github.charlietap.chasm.ast.type.Limits
 import io.github.charlietap.chasm.ast.type.ReferenceType
 import io.github.charlietap.chasm.ast.type.TableType
 
 fun tableType(
-    referenceType: ReferenceType = ReferenceType.RefNull(HeapType.Func),
+    referenceType: ReferenceType = ReferenceType.RefNull(AbstractHeapType.Func),
     limits: Limits = limits(),
 ) = TableType(
     referenceType = referenceType,

--- a/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/ExternalValue.kt
+++ b/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/ExternalValue.kt
@@ -1,0 +1,22 @@
+package io.github.charlietap.chasm.fixture.instance
+
+import io.github.charlietap.chasm.executor.runtime.instance.ExternalValue
+import io.github.charlietap.chasm.executor.runtime.store.Address
+
+fun externalValue(): ExternalValue = functionExternalValue()
+
+fun functionExternalValue(
+    address: Address.Function = functionAddress(),
+) = ExternalValue.Function(address)
+
+fun tableExternalValue(
+    address: Address.Table = tableAddress(),
+) = ExternalValue.Table(address)
+
+fun memoryExternalValue(
+    address: Address.Memory = memoryAddress(),
+) = ExternalValue.Memory(address)
+
+fun globalExternalValue(
+    address: Address.Global = globalAddress(),
+) = ExternalValue.Global(address)

--- a/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/FunctionInstance.kt
+++ b/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/FunctionInstance.kt
@@ -1,15 +1,15 @@
 package io.github.charlietap.chasm.fixture.instance
 
 import io.github.charlietap.chasm.ast.module.Function
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.executor.runtime.instance.FunctionInstance
 import io.github.charlietap.chasm.executor.runtime.instance.HostFunction
 import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.fixture.module.function
-import io.github.charlietap.chasm.fixture.type.functionType
+import io.github.charlietap.chasm.fixture.type.definedType
 
 fun hostFunctionInstance(
-    type: FunctionType = functionType(),
+    type: DefinedType = definedType(),
     function: HostFunction = { emptyList() },
 ) = FunctionInstance.HostFunction(
     type = type,
@@ -17,7 +17,7 @@ fun hostFunctionInstance(
 )
 
 fun wasmFunctionInstance(
-    type: FunctionType = functionType(),
+    type: DefinedType = definedType(),
     module: ModuleInstance = moduleInstance(),
     function: Function = function(),
 ) = FunctionInstance.WasmFunction(

--- a/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/ModuleInstance.kt
+++ b/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/instance/ModuleInstance.kt
@@ -1,12 +1,12 @@
 package io.github.charlietap.chasm.fixture.instance
 
-import io.github.charlietap.chasm.ast.type.FunctionType
+import io.github.charlietap.chasm.ast.type.DefinedType
 import io.github.charlietap.chasm.executor.runtime.instance.ExportInstance
 import io.github.charlietap.chasm.executor.runtime.instance.ModuleInstance
 import io.github.charlietap.chasm.executor.runtime.store.Address
 
 fun moduleInstance(
-    types: List<FunctionType> = emptyList(),
+    types: List<DefinedType> = emptyList(),
     functionAddresses: MutableList<Address.Function> = mutableListOf(),
     tableAddresses: MutableList<Address.Table> = mutableListOf(),
     memAddresses: MutableList<Address.Memory> = mutableListOf(),

--- a/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ExternalType.kt
+++ b/test/fixture/executor/runtime/src/commonMain/kotlin/io/github/charlietap/chasm/fixture/type/ExternalType.kt
@@ -1,0 +1,25 @@
+package io.github.charlietap.chasm.fixture.type
+
+import io.github.charlietap.chasm.ast.type.DefinedType
+import io.github.charlietap.chasm.ast.type.GlobalType
+import io.github.charlietap.chasm.ast.type.MemoryType
+import io.github.charlietap.chasm.ast.type.TableType
+import io.github.charlietap.chasm.executor.runtime.type.ExternalType
+
+fun externalType(): ExternalType = functionExternalType()
+
+fun functionExternalType(
+    definedType: DefinedType = definedType(),
+) = ExternalType.Function(definedType)
+
+fun tableExternalType(
+    tableType: TableType = tableType(),
+) = ExternalType.Table(tableType)
+
+fun memoryExternalType(
+    memoryType: MemoryType = memoryType(),
+) = ExternalType.Memory(memoryType)
+
+fun globalExternalType(
+    globalType: GlobalType = globalType(),
+) = ExternalType.Global(globalType)


### PR DESCRIPTION
- updated ast and fixtures with new types and instructions
- storage and packed type decoding
- aggregate type decoding
- composite type decoding
- refactor index fixture into module package
- recursive type decoding
- wasm gc control instructions
- refactor s33 decoding into dedicated function
- reference instruction decoding
- first stage of wasm gc proposal integration complete
