### PR TITLE
Wasm testsuite malformations

### DIFF
--- a/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/script/command/AssertMalformedCommandRunner.kt
+++ b/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/script/command/AssertMalformedCommandRunner.kt
@@ -1,13 +1,23 @@
 package io.github.charlietap.chasm.script.command
 
+import io.github.charlietap.chasm.embedding.module
+import io.github.charlietap.chasm.fold
+import io.github.charlietap.chasm.script.ScriptContext
+import io.github.charlietap.chasm.script.ext.readBytesFromPath
 import io.github.charlietap.sweet.lib.command.AssertMalformedCommand
 
-typealias AssertMalformedCommandRunner = (AssertMalformedCommand) -> CommandResult
+typealias AssertMalformedCommandRunner = (ScriptContext, AssertMalformedCommand) -> CommandResult
 
-@Suppress("UNUSED_PARAMETER")
 fun AssertMalformedCommandRunner(
+    context: ScriptContext,
     command: AssertMalformedCommand,
 ): CommandResult {
-    println("ignoring AssertMalformed")
-    return CommandResult.Success
+    val moduleFilePath = context.binaryDirectory + "/" + command.filename
+    val bytes = moduleFilePath.readBytesFromPath()
+
+    return module(bytes).fold({
+        CommandResult.Failure(command, "malformed module was decoded when it should have failed")
+    }) {
+        CommandResult.Success
+    }
 }

--- a/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/script/command/CommandRunner.kt
+++ b/chasm/src/commonTest/kotlin/io/github/charlietap/chasm/script/command/CommandRunner.kt
@@ -50,7 +50,7 @@ private fun CommandRunner(
     is ActionCommand -> actionCommandRunner(context, command)
     is AssertExhaustionCommand -> assertExhaustionCommandRunner(command)
     is AssertInvalidCommand -> assertInvalidCommandRunner(command)
-    is AssertMalformedCommand -> assertMalformedCommandRunner(command)
+    is AssertMalformedCommand -> assertMalformedCommandRunner(context, command)
     is AssertReturnCommand -> assertReturnCommandRunner(context, command)
     is AssertTrapCommand -> assertTrapCommandRunner(context, command)
     is AssertUninstantiableCommand -> assertUninstantiableCommandRunner(context, command)

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/builder/ModuleBuilder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/builder/ModuleBuilder.kt
@@ -1,7 +1,9 @@
 package io.github.charlietap.chasm.decoder.wasm.builder
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
+import io.github.charlietap.chasm.ast.instruction.MemoryInstruction
 import io.github.charlietap.chasm.ast.module.Custom
 import io.github.charlietap.chasm.ast.module.DataSegment
 import io.github.charlietap.chasm.ast.module.ElementSegment
@@ -18,6 +20,8 @@ import io.github.charlietap.chasm.ast.module.Version
 import io.github.charlietap.chasm.decoder.ModuleDecoderError
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.code.FunctionBody
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.function.FunctionHeader
+import io.github.charlietap.chasm.decoder.wasm.error.ModuleDecodeError
+import io.github.charlietap.chasm.decoder.wasm.error.SectionDecodeError
 
 internal class ModuleBuilder(private val version: Version) {
     private var types: MutableList<Type> = mutableListOf()
@@ -28,10 +32,11 @@ internal class ModuleBuilder(private val version: Version) {
     private var globals: MutableList<Global> = mutableListOf()
     private var elementSegments: MutableList<ElementSegment> = mutableListOf()
     private var dataSegments: MutableList<DataSegment> = mutableListOf()
-    private var startFunction: StartFunction? = null
+    private var startFunctions: MutableList<StartFunction> = mutableListOf()
     private var exports: MutableList<Export> = mutableListOf()
     private var imports: MutableList<Import> = mutableListOf()
     private var customs: MutableList<Custom> = mutableListOf()
+    private var dataCount: UInt? = null
 
     fun types(types: List<Type>) = apply { this.types += types }
 
@@ -53,31 +58,57 @@ internal class ModuleBuilder(private val version: Version) {
 
     fun dataSegments(dataSegments: List<DataSegment>) = apply { this.dataSegments += dataSegments }
 
-    fun start(startFunction: StartFunction) = apply { this.startFunction = startFunction }
+    fun start(startFunction: StartFunction) = apply { this.startFunctions += startFunction }
 
     fun custom(custom: Custom) = apply { customs.add(custom) }
 
-    private fun assembleFunctions(): List<Function> = functionHeaders.mapIndexed { index, header ->
-        val body = functionBodies[index]
-        Function(
-            header.idx,
-            header.typeIndex,
-            body.locals,
-            body.body,
-        )
-    }
+    fun dataCount(count: UInt) = apply { dataCount = count }
 
     fun build(): Result<Module, ModuleDecoderError> = binding {
+
+        if (functionHeaders.size != functionBodies.size) {
+            Err(ModuleDecodeError.ModuleMalformed).bind<Unit>()
+        }
+
+        if (startFunctions.size > 1) {
+            Err(SectionDecodeError.MultipleStartFunctions).bind<Unit>()
+        }
+
+        val requiresDataCount = functionBodies.any { functionBody ->
+            functionBody.body.instructions.any { instruction ->
+                instruction is MemoryInstruction.MemoryInit ||
+                    instruction is MemoryInstruction.DataDrop
+            }
+        }
+
+        if (requiresDataCount && dataCount == null) {
+            Err(SectionDecodeError.DataCountRequired).bind<Unit>()
+        }
+
+        if (dataCount != null && dataCount != dataSegments.size.toUInt()) {
+            Err(SectionDecodeError.DataCountMismatch).bind<Unit>()
+        }
+
+        val functions = functionHeaders.mapIndexed { index, header ->
+            val body = functionBodies[index]
+            Function(
+                header.idx,
+                header.typeIndex,
+                body.locals,
+                body.body,
+            )
+        }
+
         Module(
             version = version,
             types = types,
-            functions = assembleFunctions(),
+            functions = functions,
             tables = tables,
             memories = memories,
             globals = globals,
             elementSegments = elementSegments,
             dataSegments = dataSegments,
-            startFunction = startFunction,
+            startFunction = startFunctions.firstOrNull(),
             exports = exports,
             imports = imports,
             customs = customs,

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/BinaryInstructionBlockDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/BinaryInstructionBlockDecoder.kt
@@ -23,7 +23,7 @@ internal fun BinaryInstructionBlockDecoder(
     val instructions = mutableListOf<Instruction>()
     do {
         val opcode = reader.ubyte().bind()
-        if (opcode != blockEndOpcode) { // TODO make this branchless
+        if (opcode != blockEndOpcode) {
             instructions += instructionDecoder(reader, opcode).bind()
         }
     } while (opcode != blockEndOpcode)

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/memory/BinaryMemoryInstructionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/instruction/memory/BinaryMemoryInstructionDecoder.kt
@@ -74,11 +74,17 @@ internal fun BinaryMemoryInstructionDecoder(
         I64_STORE16 -> MemoryInstruction.I64Store16(memArgDecoder(reader).bind())
         I64_STORE32 -> MemoryInstruction.I64Store32(memArgDecoder(reader).bind())
         MEMORY_SIZE -> {
-            reader.byte().bind()
+            val byte = reader.byte().bind()
+            if (byte != 0.toByte()) {
+                Err(InstructionDecodeError.ReservedByteNotZero).bind<Unit>()
+            }
             MemoryInstruction.MemorySize
         }
         MEMORY_GROW -> {
-            reader.byte().bind()
+            val byte = reader.byte().bind()
+            if (byte != 0.toByte()) {
+                Err(InstructionDecodeError.ReservedByteNotZero).bind<Unit>()
+            }
             MemoryInstruction.MemoryGrow
         }
 

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/code/BinaryCodeEntryDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/code/BinaryCodeEntryDecoder.kt
@@ -1,5 +1,6 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.section.code
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Index
@@ -8,6 +9,7 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.BinaryExpress
 import io.github.charlietap.chasm.decoder.wasm.decoder.instruction.ExpressionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryVectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.VectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.SectionDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
@@ -29,9 +31,13 @@ internal fun BinaryCodeEntryDecoder(
 ): Result<CodeEntry, WasmDecodeError> = binding {
 
     val size = reader.uint().bind()
-
     val localEntries = vectorDecoder(reader, localEntryDecoder).bind()
     var index = 0u
+
+    if (localEntries.vector.sumOf { it.count.toULong() } > UInt.MAX_VALUE.toULong()) {
+        Err(SectionDecodeError.TooManyLocals).bind<Unit>()
+    }
+
     val locals = mutableListOf<Local>()
     localEntries.vector.forEach { entry ->
         repeat(entry.count.toInt()) {

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/custom/BinaryCustomSectionDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/custom/BinaryCustomSectionDecoder.kt
@@ -1,10 +1,12 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.section.custom
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.module.Custom
 import io.github.charlietap.chasm.decoder.wasm.decoder.value.name.BinaryNameValueDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.value.name.NameValueDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.SectionDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.ext.trackBytes
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
@@ -26,6 +28,10 @@ internal class BinaryCustomSectionDecoder(
         val nameValue = nameResult.bind()
         val payloadSize = size.size - bytesConsumed
         val payload = reader.ubytes(payloadSize).bind()
+
+        if (payloadSize != payload.size.toUInt()) {
+            Err(SectionDecodeError.SectionSizeMismatch).bind<Unit>()
+        }
 
         CustomSection(Custom(nameValue, payload))
     }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/value/name/BinaryNameValueDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/value/name/BinaryNameValueDecoder.kt
@@ -1,10 +1,13 @@
 package io.github.charlietap.chasm.decoder.wasm.decoder.value.name
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import io.github.charlietap.chasm.ast.value.NameValue
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.BinaryByteVectorDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.vector.ByteVectorDecoder
+import io.github.charlietap.chasm.decoder.wasm.error.ValueDecodeError
 import io.github.charlietap.chasm.decoder.wasm.error.WasmDecodeError
 import io.github.charlietap.chasm.decoder.wasm.reader.WasmBinaryReader
 
@@ -18,6 +21,11 @@ internal fun BinaryNameValueDecoder(
 ): Result<NameValue, WasmDecodeError> = binding {
 
     val vector = vectorDecoder(reader).bind()
+    val name = try {
+        Ok(vector.bytes.asByteArray().decodeToString(throwOnInvalidSequence = true))
+    } catch (e: Exception) {
+        Err(ValueDecodeError.InvalidName(vector.bytes))
+    }.bind()
 
-    NameValue(vector.bytes.asByteArray().decodeToString())
+    NameValue(name)
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/vector/BinaryVectorDecoder.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/vector/BinaryVectorDecoder.kt
@@ -12,7 +12,7 @@ internal fun <T> BinaryVectorDecoder(
 
     val vecLength = reader.uint().bind()
 
-    val vector = (1u..vecLength).map {
+    val vector = List(vecLength.toInt()) {
         subDecoder(reader).bind()
     }
 

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/InstructionDecodeError.kt
@@ -32,4 +32,6 @@ sealed interface InstructionDecodeError : WasmDecodeError {
     value class InvalidCastFlags(val byte: UByte) : InstructionDecodeError
 
     data class InvalidPrefixInstruction(val prefix: UByte, val opcode: UInt) : InstructionDecodeError
+
+    data object ReservedByteNotZero : InstructionDecodeError
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/ModuleDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/ModuleDecodeError.kt
@@ -1,3 +1,7 @@
 package io.github.charlietap.chasm.decoder.wasm.error
 
-sealed interface ModuleDecodeError : WasmDecodeError
+import io.github.charlietap.chasm.decoder.ModuleDecoderError
+
+sealed interface ModuleDecodeError : WasmDecodeError {
+    data object ModuleMalformed : ModuleDecoderError
+}

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/SectionDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/SectionDecodeError.kt
@@ -23,4 +23,14 @@ sealed interface SectionDecodeError : WasmDecodeError {
 
     @JvmInline
     value class UnknownElementKind(val byte: Byte) : SectionDecodeError
+
+    data object MultipleStartFunctions : SectionDecodeError
+
+    data object DataCountMismatch : SectionDecodeError
+
+    data object DataCountRequired : SectionDecodeError
+
+    data object SectionSizeMismatch : SectionDecodeError
+
+    data object TooManyLocals : SectionDecodeError
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/ValueDecodeError.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/error/ValueDecodeError.kt
@@ -9,4 +9,7 @@ interface ValueDecodeError : WasmDecodeError {
 
     @JvmInline
     value class InvalidDouble(val bytes: ByteArray) : ValueDecodeError
+
+    @JvmInline
+    value class InvalidName(val bytes: UByteArray) : ValueDecodeError
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/ext/ModuleBuilderExt.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/ext/ModuleBuilderExt.kt
@@ -29,5 +29,5 @@ internal fun ModuleBuilder.section(section: Section) = when (section) {
     is MemorySection -> memories(section.memories)
     is GlobalSection -> globals(section.globals)
     is StartSection -> start(section.startFunction)
-    is DataCountSection -> this
+    is DataCountSection -> dataCount(section.dataCount)
 }

--- a/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/ext/SequenceExt.kt
+++ b/decoder/wasm/src/commonMain/kotlin/io/github/charlietap/chasm/decoder/wasm/ext/SequenceExt.kt
@@ -1,5 +1,11 @@
 package io.github.charlietap.chasm.decoder.wasm.ext
 
+private const val CONTINUATION_BIT = 1 shl 7
+private const val SIGN_BIT = 1 shl 6
+
+private const val MAX_SHIFT_INT = 35
+private const val MAX_SHIFT_LONG = 70
+
 internal fun Sequence<Byte>.toIntLeb128(): Int {
     val iterator = iterator()
     var result = 0
@@ -11,9 +17,20 @@ internal fun Sequence<Byte>.toIntLeb128(): Int {
         val value = byte and 0x7F
         result = result or (value shl shift)
         shift += 7
-    } while (byte and 0x80 != 0)
+    } while (byte and CONTINUATION_BIT != 0)
 
-    if (byte and 0x40 != 0 && shift < 32) {
+    if (shift >= Int.SIZE_BITS) {
+        if (shift > MAX_SHIFT_INT) {
+            throw IllegalArgumentException("integer too large")
+        }
+
+        val mask = ((-1 shl ((Int.SIZE_BITS % 7) - 1)) and 0x7F)
+        if (byte and mask != 0 && byte < mask) {
+            throw IllegalArgumentException("integer too large or contains unnecessary high bits")
+        }
+    }
+
+    if (byte and SIGN_BIT != 0 && shift < Int.SIZE_BITS) {
         result = result or (-1 shl shift)
     }
 
@@ -31,9 +48,20 @@ internal fun Sequence<Byte>.toLongLeb128(): Long {
         val value = byte and 0x7F
         result = result or (value.toLong() shl shift)
         shift += 7
-    } while (byte and 0x80 != 0)
+    } while (byte and CONTINUATION_BIT != 0)
 
-    if (byte and 0x40 != 0 && shift < 64) {
+    if (shift >= Long.SIZE_BITS) {
+        if (shift > MAX_SHIFT_LONG) {
+            throw IllegalArgumentException("integer too large")
+        }
+
+        val mask = ((-1 shl ((Long.SIZE_BITS % 7) - 1)) and 0x7F)
+        if (byte and mask != 0 && byte < mask) {
+            throw IllegalArgumentException("integer too large or contains unnecessary high bits")
+        }
+    }
+
+    if (byte and SIGN_BIT != 0 && shift < Long.SIZE_BITS) {
         result = result or (-1L shl shift)
     }
 
@@ -49,9 +77,14 @@ internal fun Sequence<UByte>.toUIntLeb128(): UInt {
 
     do {
         byte = iter.next()
-        result = result or ((byte and 0x7Fu).toUInt() shl shift)
+        val value = (byte and 0x7Fu).toUInt()
+        result = result or (value shl shift)
         shift += 7
-    } while (byte and 0x80u.toUByte() != 0u.toUByte())
+    } while (byte and CONTINUATION_BIT.toUByte() != 0u.toUByte())
+
+    if (shift > MAX_SHIFT_INT || (shift == MAX_SHIFT_INT && byte and 0xF0u != 0.toUByte())) {
+        throw IllegalArgumentException("unsigned integer too large")
+    }
 
     return result
 }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/BinarySectionDecoderTest.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/decoder/section/BinarySectionDecoderTest.kt
@@ -18,7 +18,7 @@ import io.github.charlietap.chasm.decoder.wasm.decoder.section.memory.MemorySect
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.start.StartSectionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.table.TableSectionDecoder
 import io.github.charlietap.chasm.decoder.wasm.decoder.section.type.TypeSectionDecoder
-import io.github.charlietap.chasm.decoder.wasm.reader.FakeWasmBinaryReader
+import io.github.charlietap.chasm.decoder.wasm.reader.FakePositionReader
 import io.github.charlietap.chasm.decoder.wasm.section.CodeSection
 import io.github.charlietap.chasm.decoder.wasm.section.CustomSection
 import io.github.charlietap.chasm.decoder.wasm.section.DataCountSection
@@ -47,6 +47,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = CustomSection(Custom(NameValue(""), ubyteArrayOf()))
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val customSectionDecoder = CustomSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -54,7 +59,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(customSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -67,6 +72,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = TypeSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val typeSectionDecoder = TypeSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -74,7 +84,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(typeSectionDecoder = typeSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -87,6 +97,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = FunctionSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val functionSectionDecoder = FunctionSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -94,7 +109,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(functionSectionDecoder = functionSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -107,6 +122,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = GlobalSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val globalSectionDecoder = GlobalSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -114,7 +134,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(globalSectionDecoder = globalSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -127,6 +147,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = MemorySection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val memorySectionDecoder = MemorySectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -134,7 +159,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(memorySectionDecoder = memorySectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -147,6 +172,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = ImportSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val importSectionDecoder = ImportSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -154,7 +184,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(importSectionDecoder = importSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -167,6 +197,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = TableSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val tableSectionDecoder = TableSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -174,7 +209,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(tableSectionDecoder = tableSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -187,6 +222,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = ExportSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val exportSectionDecoder = ExportSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -194,7 +234,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(exportSectionDecoder = exportSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -207,6 +247,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = StartSection(StartFunction(Index.FunctionIndex(117u)))
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val startSectionDecoder = StartSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -214,7 +259,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(startSectionDecoder = startSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -227,6 +272,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = CodeSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val codeSectionDecoder = CodeSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -234,7 +284,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(codeSectionDecoder = codeSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -247,6 +297,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = DataSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val dataSectionDecoder = DataSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -254,7 +309,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(dataSectionDecoder = dataSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -267,6 +322,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = DataCountSection(117u)
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val dataCountSectionDecoder = DataCountSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -274,7 +334,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(dataCountSectionDecoder = dataCountSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }
@@ -287,6 +347,11 @@ class BinarySectionDecoderTest {
 
         val expectedSection = ElementSection(emptyList())
 
+        val positions = sequenceOf(0u, secSize.size).iterator()
+        val reader = FakePositionReader {
+            positions.next()
+        }
+
         val elementSectionDecoder = ElementSectionDecoder { _, size ->
             assertEquals(secSize, size)
             Ok(expectedSection)
@@ -294,7 +359,7 @@ class BinarySectionDecoderTest {
 
         val decoder = BinarySectionDecoder(elementSectionDecoder = elementSectionDecoder)
 
-        val actual = decoder(FakeWasmBinaryReader(), type, secSize)
+        val actual = decoder(reader, type, secSize)
 
         assertEquals(Ok(expectedSection), actual)
     }

--- a/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/FakeWasmBinaryReader.kt
+++ b/decoder/wasm/src/commonTest/kotlin/io/github/charlietap/chasm/decoder/wasm/reader/FakeWasmBinaryReader.kt
@@ -95,3 +95,7 @@ internal fun FakeUBytesReader(
 internal fun FakeExhaustedReader(
     exhausted: () -> Result<Boolean, WasmDecodeError>,
 ): WasmBinaryReader = FakeWasmBinaryReader(fakeExhaustedReader = exhausted)
+
+internal fun FakePositionReader(
+    position: () -> UInt,
+): WasmBinaryReader = FakeWasmBinaryReader(fakePositionReader = position)


### PR DESCRIPTION
ensure reserved bytes are zero

ensure leb128 do not overflow

ensure max locals is 2^32-1

decode data count and use it to verify data segments size

catch multiple start functions

require data count when memory instructions are present

ensure sections are consumed

ensure sections match size declared

catch case where custom section is malformed

ensure name values are correctly encoded utf8

catch leb128 cases of poor encoding
